### PR TITLE
[FEAT] User 탈퇴 기능 구현

### DIFF
--- a/src/main/java/com/yju/toonovel/domain/user/controller/UserController.java
+++ b/src/main/java/com/yju/toonovel/domain/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.yju.toonovel.domain.user.controller;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -31,9 +32,14 @@ public class UserController {
 		return userService.getUserProfile(user.userId);
 	}
 
+	@DeleteMapping("/me")
+	public void deleteUser(@AuthenticationPrincipal JwtAuthentication user) {
+		userService.deleteUser(user.userId);
+	}
+
 	@PatchMapping("/register")
 	public void userRegister(@RequestBody UserRegisterRequestDto requestDto,
-			@AuthenticationPrincipal JwtAuthentication user) {
+		@AuthenticationPrincipal JwtAuthentication user) {
 		userService.register(user.userId, requestDto);
 	}
 }


### PR DESCRIPTION
### 📌 개발 개요
- resolve #17 
- 회원 탈퇴 + RefreshToken 삭제 처리
  <br>

### 💻  작업 및 변경 사항
- `UserController` @DeleteMapping("/me")
- `UserService` deleteUser() 메소드
  <br>

### ✅ Point
- 이전 작업에서 빠졌던 탈퇴 기능 구현하였습니다. 
- RefreshToken이 없는 예외는 의도적으로 발생시키지 않았습니다. 
- Controller에서 ~~~Profile   형태로 이름을 통일할까 하다가, 일단은 그대로 뒀습니다.
deleteMyProfile, getMyProfile, registerMyProfile 이런 식으로 네이밍 통일하는 게 좋을까요? 
  <br>