### PR TITLE
[FEAT] Business Exception 처리 구현

### DIFF
--- a/src/main/java/com/yju/toonovel/domain/novel/exception/NovelNotFoundException.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/exception/NovelNotFoundException.java
@@ -1,16 +1,12 @@
 package com.yju.toonovel.domain.novel.exception;
 
+import com.yju.toonovel.global.error.exception.BusinessException;
 import com.yju.toonovel.global.error.exception.ErrorCode;
 
-import lombok.Getter;
-
-@Getter
-public class NovelNotFoundException extends RuntimeException {
-
-	private final ErrorCode errorCode;
+public class NovelNotFoundException extends BusinessException {
 
 	public NovelNotFoundException() {
-		this.errorCode = ErrorCode.NOVEL_NOT_FOUND;
+		super(ErrorCode.NOVEL_NOT_FOUND);
 	}
 
 }

--- a/src/main/java/com/yju/toonovel/domain/novel/exception/PlatformNotFoundException.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/exception/PlatformNotFoundException.java
@@ -1,16 +1,12 @@
 package com.yju.toonovel.domain.novel.exception;
 
+import com.yju.toonovel.global.error.exception.BusinessException;
 import com.yju.toonovel.global.error.exception.ErrorCode;
 
-import lombok.Getter;
-
-@Getter
-public class PlatformNotFoundException extends RuntimeException {
-
-	private final ErrorCode errorCode;
+public class PlatformNotFoundException extends BusinessException {
 
 	public PlatformNotFoundException() {
-		this.errorCode = ErrorCode.PLATFORM_NOT_FOUND;
+		super(ErrorCode.PLATFORM_NOT_FOUND);
 	}
 
 }

--- a/src/main/java/com/yju/toonovel/domain/user/exception/InvalidUserException.java
+++ b/src/main/java/com/yju/toonovel/domain/user/exception/InvalidUserException.java
@@ -1,15 +1,11 @@
 package com.yju.toonovel.domain.user.exception;
 
+import com.yju.toonovel.global.error.exception.BusinessException;
 import com.yju.toonovel.global.error.exception.ErrorCode;
 
-import lombok.Getter;
-
-@Getter
-public class InvalidUserException extends RuntimeException {
-
-	private final ErrorCode errorCode;
+public class InvalidUserException extends BusinessException {
 
 	public InvalidUserException() {
-		this.errorCode = ErrorCode.USER_INVALID;
+		super(ErrorCode.USER_INVALID);
 	}
 }

--- a/src/main/java/com/yju/toonovel/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/yju/toonovel/domain/user/exception/UserNotFoundException.java
@@ -1,16 +1,12 @@
 package com.yju.toonovel.domain.user.exception;
 
+import com.yju.toonovel.global.error.exception.BusinessException;
 import com.yju.toonovel.global.error.exception.ErrorCode;
 
-import lombok.Getter;
-
-@Getter
-public class UserNotFoundException extends RuntimeException {
-
-	private final ErrorCode errorCode;
+public class UserNotFoundException extends BusinessException {
 
 	public UserNotFoundException() {
-		this.errorCode = ErrorCode.USER_NOT_FOUND;
+		super(ErrorCode.USER_NOT_FOUND);
 	}
 
 }

--- a/src/main/java/com/yju/toonovel/global/error/ErrorResponse.java
+++ b/src/main/java/com/yju/toonovel/global/error/ErrorResponse.java
@@ -4,20 +4,24 @@ import org.springframework.http.HttpStatus;
 
 import com.yju.toonovel.global.error.exception.ErrorCode;
 
-import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class ErrorResponse {
 
 	private HttpStatus status;
 	private String code;
 	private String message;
 
-	@Builder
-	public ErrorResponse(ErrorCode errorCode) {
-		this.status = errorCode.getStatus();
-		this.code = errorCode.getCode();
-		this.message = errorCode.getMessage();
+	private ErrorResponse(final ErrorCode code) {
+		this.message = code.getMessage();
+		this.status = code.getStatus();
+		this.code = code.getCode();
+	}
+
+	public static ErrorResponse of(final ErrorCode code) {
+		return new ErrorResponse(code);
 	}
 }

--- a/src/main/java/com/yju/toonovel/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/yju/toonovel/global/error/GlobalExceptionHandler.java
@@ -24,7 +24,7 @@ public class GlobalExceptionHandler {
 
 	//비즈니스 에러
 	@ExceptionHandler(BusinessException.class)
-	protected ResponseEntity<ErrorResponse> handleBusinessException(final BusinessException ex) {
+	public ResponseEntity<ErrorResponse> handleBusinessException(final BusinessException ex) {
 		log.error("handleEntityNotFoundException", ex);
 		final ErrorCode errorCode = ex.getErrorCode();
 		final ErrorResponse response = ErrorResponse.of(errorCode);

--- a/src/main/java/com/yju/toonovel/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/yju/toonovel/global/error/GlobalExceptionHandler.java
@@ -1,17 +1,18 @@
 package com.yju.toonovel.global.error;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestValueException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
+import com.yju.toonovel.global.error.exception.BusinessException;
 import com.yju.toonovel.global.error.exception.ErrorCode;
 
 import lombok.extern.slf4j.Slf4j;
@@ -21,53 +22,71 @@ import lombok.extern.slf4j.Slf4j;
 @RestController
 public class GlobalExceptionHandler {
 
-	@ResponseStatus(value = HttpStatus.BAD_REQUEST)
+	//비즈니스 에러
+	@ExceptionHandler(BusinessException.class)
+	protected ResponseEntity<ErrorResponse> handleBusinessException(final BusinessException ex) {
+		log.error("handleEntityNotFoundException", ex);
+		final ErrorCode errorCode = ex.getErrorCode();
+		final ErrorResponse response = ErrorResponse.of(errorCode);
+		return new ResponseEntity<>(response, errorCode.getStatus());
+	}
+
+	//바인딩 에러 - @RequestBody, @RequestPart 입력 값 의심
 	@ExceptionHandler(MethodArgumentNotValidException.class)
-	public ErrorResponse handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
+	public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
 		log.info("MethodArgumentNotValidException : {}", ex.getMessage());
-		return new ErrorResponse(ErrorCode.INVALID_INPUT_VALUE);
+		final ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE);
+		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
 	}
 
-	@ResponseStatus(value = HttpStatus.BAD_REQUEST)
+	//바인딩 에러 - @RequestParam Enum Type 의심
 	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
-	public ErrorResponse handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException ex) {
+	public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
+		MethodArgumentTypeMismatchException ex) {
 		log.info("MethodArgumentTypeMismatchException : {}", ex.getMessage());
-		return new ErrorResponse(ErrorCode.INVALID_TYPE_VALUE);
+		final ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_TYPE_VALUE);
+		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
 	}
 
-	@ResponseStatus(value = HttpStatus.BAD_REQUEST)
+	//입력 인자 수 부족
 	@ExceptionHandler(MissingRequestValueException.class)
-	public ErrorResponse handleMissingRequestValueException(MissingRequestValueException ex) {
+	public ResponseEntity<ErrorResponse> handleMissingRequestValueException(MissingRequestValueException ex) {
 		log.info("MissingRequestValueException : {}", ex.getMessage());
-		return new ErrorResponse(ErrorCode.MISSING_INPUT_VALUE);
+		final ErrorResponse response = ErrorResponse.of(ErrorCode.MISSING_INPUT_VALUE);
+		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
 	}
 
-	@ResponseStatus(value = HttpStatus.BAD_REQUEST)
+	//없는 API 요청
 	@ExceptionHandler(NoHandlerFoundException.class)
-	public ErrorResponse handleNoHandlerFoundException(NoHandlerFoundException ex) {
+	public ResponseEntity<ErrorResponse> handleNoHandlerFoundException(NoHandlerFoundException ex) {
 		log.info("NoHandlerFoundException : {}", ex.getMessage());
-		return new ErrorResponse(ErrorCode.NOT_EXIST_API);
+		final ErrorResponse response = ErrorResponse.of(ErrorCode.NOT_EXIST_API);
+		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
 	}
 
-	@ResponseStatus(value = HttpStatus.METHOD_NOT_ALLOWED)
+	//잘못된 HttpMethod 요청
 	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-	public ErrorResponse handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException ex) {
+	public ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(
+		HttpRequestMethodNotSupportedException ex) {
 		log.info("HttpRequestMethodNotSupportedException : {}", ex.getMessage());
-		return new ErrorResponse(ErrorCode.METHOD_NOT_ALLOWED);
+		final ErrorResponse response = ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED);
+		return new ResponseEntity<>(response, HttpStatus.METHOD_NOT_ALLOWED);
 	}
 
-	@ResponseStatus(value = HttpStatus.FORBIDDEN)
+	//권한 미보유
 	@ExceptionHandler(AccessDeniedException.class)
-	public ErrorResponse handleAccessDeniedException(AccessDeniedException ex) {
+	public ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException ex) {
 		log.info("AccessDeniedException : {}", ex.getMessage());
-		return new ErrorResponse(ErrorCode.HANDLE_ACCESS_DENIED);
+		final ErrorResponse response = ErrorResponse.of(ErrorCode.HANDLE_ACCESS_DENIED);
+		return new ResponseEntity<>(response, HttpStatus.FORBIDDEN);
 	}
 
-	// @ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR)
-	// @ExceptionHandler(Exception.class)
-	// public ErrorResponse handleInternalServerException(Exception ex) {
-	// 	log.info("handleInternalServerException : {}", ex.getMessage());
-	// 	return new ErrorResponse(ErrorCode.INTERNAL_SERVER_ERROR);
-	// }
+	//정의되지 않은 모든 에러
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ErrorResponse> handleInternalServerException(Exception ex) {
+		log.info("handleInternalServerException : {}", ex.getMessage());
+		final ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
+		return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+	}
 
 }

--- a/src/main/java/com/yju/toonovel/global/error/exception/BusinessException.java
+++ b/src/main/java/com/yju/toonovel/global/error/exception/BusinessException.java
@@ -1,0 +1,20 @@
+package com.yju.toonovel.global.error.exception;
+
+public class BusinessException extends RuntimeException {
+
+	private final ErrorCode errorCode;
+
+	public BusinessException(String message, ErrorCode errorCode) {
+		super(message);
+		this.errorCode = errorCode;
+	}
+
+	public BusinessException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
+
+	public ErrorCode getErrorCode() {
+		return errorCode;
+	}
+}

--- a/src/main/java/com/yju/toonovel/global/security/jwt/exception/ExpiredRefreshTokenException.java
+++ b/src/main/java/com/yju/toonovel/global/security/jwt/exception/ExpiredRefreshTokenException.java
@@ -1,15 +1,11 @@
 package com.yju.toonovel.global.security.jwt.exception;
 
+import com.yju.toonovel.global.error.exception.BusinessException;
 import com.yju.toonovel.global.error.exception.ErrorCode;
 
-import lombok.Getter;
-
-@Getter
-public class ExpiredRefreshTokenException extends RuntimeException {
-
-	private final ErrorCode errorCode;
+public class ExpiredRefreshTokenException extends BusinessException {
 
 	public ExpiredRefreshTokenException() {
-		this.errorCode = ErrorCode.EXPIRED_REFRESH_TOKEN;
+		super(ErrorCode.EXPIRED_REFRESH_TOKEN);
 	}
 }

--- a/src/main/java/com/yju/toonovel/global/security/jwt/exception/ExpiredTokenException.java
+++ b/src/main/java/com/yju/toonovel/global/security/jwt/exception/ExpiredTokenException.java
@@ -1,15 +1,11 @@
 package com.yju.toonovel.global.security.jwt.exception;
 
+import com.yju.toonovel.global.error.exception.BusinessException;
 import com.yju.toonovel.global.error.exception.ErrorCode;
 
-import lombok.Getter;
-
-@Getter
-public class ExpiredTokenException extends RuntimeException {
-
-	private final ErrorCode errorCode;
+public class ExpiredTokenException extends BusinessException {
 
 	public ExpiredTokenException() {
-		this.errorCode = ErrorCode.EXPIRED_TOKEN;
+		super(ErrorCode.EXPIRED_TOKEN);
 	}
 }

--- a/src/main/java/com/yju/toonovel/global/security/jwt/exception/InvalidTokenException.java
+++ b/src/main/java/com/yju/toonovel/global/security/jwt/exception/InvalidTokenException.java
@@ -1,15 +1,11 @@
 package com.yju.toonovel.global.security.jwt.exception;
 
+import com.yju.toonovel.global.error.exception.BusinessException;
 import com.yju.toonovel.global.error.exception.ErrorCode;
 
-import lombok.Getter;
-
-@Getter
-public class InvalidTokenException extends RuntimeException {
-
-	private final ErrorCode errorCode;
+public class InvalidTokenException extends BusinessException {
 
 	public InvalidTokenException() {
-		this.errorCode = ErrorCode.INVALID_TOKEN;
+		super(ErrorCode.INVALID_TOKEN);
 	}
 }

--- a/src/main/java/com/yju/toonovel/global/security/jwt/filter/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/yju/toonovel/global/security/jwt/filter/JwtAuthenticationEntryPoint.java
@@ -28,7 +28,8 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 		response.setStatus(UNAUTHORIZED.value());
 		response.setCharacterEncoding("UTF-8");
 		response.setContentType("application/json");
-		response.getWriter().write(String.valueOf(new ErrorResponse(ErrorCode.HANDLE_ACCESS_DENIED)));
+		response.getWriter()
+			.write(String.valueOf(ErrorResponse.of(ErrorCode.HANDLE_ACCESS_DENIED)));
 
 	}
 }


### PR DESCRIPTION
### 📌 개발 개요
- resolve #23 
- `Business Exception`을 구현하여, `Service` 레이어에서 발생한 에러들의 원인을 제대로 반환하도록 하였습니다.
  <br>

### 💻  작업 및 변경 사항
- `Business Exception` 구현
  - `ErrorResponse` 수정
  - `GlobalExceptionHandler` 수정
  - 이전에 구현된 `Custom Exception` 수정
  <br>

### ✅ Point
- 이후에 작업하시는 도메인, 기능들에 대해서 필요한 예외가 있다면 구현하여 작업해주시면 됩니다.
- 이전에 주석 처리했던 `handleInternalServerException`의 주석 처리를 해제했습니다.               
  <br>