### PR TITLE
[FEAT] 소설 검색 기능 구현 및 조회 기능 수정

### DIFF
--- a/src/main/java/com/yju/toonovel/domain/novel/controller/NovelController.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/controller/NovelController.java
@@ -6,11 +6,12 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.yju.toonovel.domain.novel.dto.NovelDetailResponseDto;
+import com.yju.toonovel.domain.novel.dto.NovelPaginationRequestDto;
 import com.yju.toonovel.domain.novel.dto.NovelPaginationResponseDto;
 import com.yju.toonovel.domain.novel.dto.UserLikeCheckResponseDto;
 import com.yju.toonovel.domain.novel.service.NovelService;
@@ -26,8 +27,8 @@ public class NovelController {
 	private final NovelService novelService;
 
 	@GetMapping
-	public List<NovelPaginationResponseDto> getAllNovel(@RequestParam Long novelId) {
-		return novelService.findAll(novelId);
+	public List<NovelPaginationResponseDto> getAllNovel(@RequestBody NovelPaginationRequestDto requestDto) {
+		return novelService.findAll(requestDto);
 	}
 
 	@GetMapping("/{novelId}")
@@ -37,10 +38,8 @@ public class NovelController {
 
 	@PutMapping("/{novelId}/like")
 	public void toggleLike(
-		@AuthenticationPrincipal
-		JwtAuthentication user,
-		@PathVariable
-		Long novelId
+		@AuthenticationPrincipal JwtAuthentication user,
+		@PathVariable Long novelId
 	) {
 		novelService.toggleNovelLike(user.userId, novelId);
 	}

--- a/src/main/java/com/yju/toonovel/domain/novel/controller/NovelController.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/controller/NovelController.java
@@ -4,9 +4,9 @@ import java.util.List;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -27,7 +27,7 @@ public class NovelController {
 	private final NovelService novelService;
 
 	@GetMapping
-	public List<NovelPaginationResponseDto> getAllNovel(@RequestBody NovelPaginationRequestDto requestDto) {
+	public List<NovelPaginationResponseDto> getAllNovel(@ModelAttribute NovelPaginationRequestDto requestDto) {
 		return novelService.findAll(requestDto);
 	}
 

--- a/src/main/java/com/yju/toonovel/domain/novel/dto/NovelDetailResponseDto.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/dto/NovelDetailResponseDto.java
@@ -2,11 +2,9 @@ package com.yju.toonovel.domain.novel.dto;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import com.yju.toonovel.domain.novel.entity.Genre;
 import com.yju.toonovel.domain.novel.entity.Novel;
-import com.yju.toonovel.domain.novel.entity.NovelPlatform;
 import com.yju.toonovel.domain.novel.entity.Platform;
 
 import lombok.Getter;

--- a/src/main/java/com/yju/toonovel/domain/novel/dto/NovelPaginationRequestDto.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/dto/NovelPaginationRequestDto.java
@@ -1,0 +1,24 @@
+package com.yju.toonovel.domain.novel.dto;
+
+import com.yju.toonovel.domain.novel.entity.Genre;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NovelPaginationRequestDto {
+
+	private Long novelId;
+	private String title;
+	private String author;
+	private Genre genre;
+
+	public NovelPaginationRequestDto(Long novelId, String title, String author, Genre genre) {
+		this.novelId = novelId;
+		this.title = title;
+		this.author = author;
+		this.genre = genre;
+	}
+
+}

--- a/src/main/java/com/yju/toonovel/domain/novel/entity/Genre.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/entity/Genre.java
@@ -1,5 +1,8 @@
 package com.yju.toonovel.domain.novel.entity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -16,5 +19,20 @@ public enum Genre {
 	BL("BL");
 
 	private final String key;
+
+	@JsonCreator
+	public static Genre from(String name) {
+		for (Genre genre : Genre.values()) {
+			if (genre.name().equals(name)) {
+				return genre;
+			}
+		}
+		return null;
+	}
+
+	@JsonValue
+	public String getGenreName() {
+		return key;
+	}
 
 }

--- a/src/main/java/com/yju/toonovel/domain/novel/entity/Novel.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/entity/Novel.java
@@ -16,7 +16,6 @@ import javax.persistence.OneToMany;
 
 import org.hibernate.annotations.Formula;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.yju.toonovel.global.common.entity.BaseEntity;
 
 import lombok.Getter;
@@ -34,7 +33,7 @@ public class Novel extends BaseEntity {
 	@Column(name = "title", nullable = false)
 	private String title;
 
-	@Column(name = "description", nullable = false)
+	@Column(name = "description", nullable = false, length = 10000)
 	private String description;
 
 	@Column(name = "author", nullable = false)
@@ -51,7 +50,7 @@ public class Novel extends BaseEntity {
 	@OneToMany(mappedBy = "novel")
 	private List<NovelPlatform> novelPlatforms = new ArrayList<>();
 
-	@Column(name = "image", nullable = false)
+	@Column(name = "image", nullable = false, length = 2000)
 	private String image;
 
 }

--- a/src/main/java/com/yju/toonovel/domain/novel/repository/NovelCustomRepository.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/repository/NovelCustomRepository.java
@@ -1,11 +1,10 @@
 package com.yju.toonovel.domain.novel.repository;
 
 import java.util.List;
-import java.util.Optional;
 
-import com.yju.toonovel.domain.novel.dto.NovelDetailResponseDto;
+import com.yju.toonovel.domain.novel.dto.NovelPaginationRequestDto;
 import com.yju.toonovel.domain.novel.entity.Novel;
 
 public interface NovelCustomRepository {
-	List<Novel> findAllNovel(Long novelId);
+	List<Novel> findAllNovel(NovelPaginationRequestDto requestDto);
 }

--- a/src/main/java/com/yju/toonovel/domain/novel/repository/NovelCustomRepositoryImpl.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/repository/NovelCustomRepositoryImpl.java
@@ -1,18 +1,16 @@
 package com.yju.toonovel.domain.novel.repository;
 
 import static com.yju.toonovel.domain.novel.entity.QNovel.*;
-import static com.yju.toonovel.domain.novel.entity.QNovelPlatform.*;
-import static com.yju.toonovel.domain.novel.entity.QPlatform.*;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
-import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.yju.toonovel.domain.novel.dto.NovelDetailResponseDto;
+import com.yju.toonovel.domain.novel.dto.NovelPaginationRequestDto;
+import com.yju.toonovel.domain.novel.entity.Genre;
 import com.yju.toonovel.domain.novel.entity.Novel;
 
 import lombok.RequiredArgsConstructor;
@@ -24,22 +22,49 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
 	private final JPAQueryFactory jpaQueryFactory;
 
 	@Override
-	public List<Novel> findAllNovel(Long novelId) {
+	public List<Novel> findAllNovel(NovelPaginationRequestDto requestDto) {
 		return jpaQueryFactory
 			.selectFrom(novel)
 			.where(
-				gtNovelId(novelId)
+				ltNovelId(requestDto.getNovelId()),
+				eqGenre(requestDto.getGenre()),
+				eqTitle(requestDto.getTitle()),
+				eqAuthor(requestDto.getAuthor())
 			)
 			.limit(30)
+			.orderBy(
+				novel.novelId.desc()
+			)
 			.fetch();
 	}
 
-	private BooleanExpression gtNovelId(Long novelId) {
+	private BooleanExpression ltNovelId(Long novelId) {
 		if (novelId == null) {
 			return null;
 		}
 
-		return novel.novelId.gt(novelId);
+		return novel.novelId.lt(novelId);
+	}
+
+	private Predicate eqGenre(Genre genre) {
+		if (genre == null) {
+			return null;
+		}
+		return novel.genre.eq(genre);
+	}
+
+	private Predicate eqTitle(String title) {
+		if (title == null) {
+			return null;
+		}
+		return novel.title.contains(title);
+	}
+
+	private Predicate eqAuthor(String author) {
+		if (author == null) {
+			return null;
+		}
+		return novel.author.contains(author);
 	}
 
 }

--- a/src/main/java/com/yju/toonovel/domain/novel/service/NovelService.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/service/NovelService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.yju.toonovel.domain.novel.dto.NovelDetailResponseDto;
+import com.yju.toonovel.domain.novel.dto.NovelPaginationRequestDto;
 import com.yju.toonovel.domain.novel.dto.NovelPaginationResponseDto;
 import com.yju.toonovel.domain.novel.dto.UserLikeCheckResponseDto;
 import com.yju.toonovel.domain.novel.entity.LikeNovel;
@@ -36,9 +37,9 @@ public class NovelService {
 	private final PlatformRepository platformRepository;
 
 	@Transactional
-	public List<NovelPaginationResponseDto> findAll(Long novelId) {
+	public List<NovelPaginationResponseDto> findAll(NovelPaginationRequestDto requestDto) {
 		return novelRepository
-			.findAllNovel(novelId)
+			.findAllNovel(requestDto)
 			.stream()
 			.map(novel -> NovelPaginationResponseDto.from(novel))
 			.collect(Collectors.toList());

--- a/src/main/java/com/yju/toonovel/domain/user/controller/UserController.java
+++ b/src/main/java/com/yju/toonovel/domain/user/controller/UserController.java
@@ -7,7 +7,6 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;

--- a/src/main/java/com/yju/toonovel/domain/user/service/UserService.java
+++ b/src/main/java/com/yju/toonovel/domain/user/service/UserService.java
@@ -7,14 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.yju.toonovel.domain.novel.dto.NovelPaginationResponseDto;
-import com.yju.toonovel.domain.novel.dto.UserLikeCheckResponseDto;
-import com.yju.toonovel.domain.novel.entity.LikeNovel;
-import com.yju.toonovel.domain.novel.entity.Novel;
-import com.yju.toonovel.domain.novel.exception.NovelNotFoundException;
 import com.yju.toonovel.domain.novel.repository.LikeNovelRepository;
-import com.yju.toonovel.domain.novel.repository.NovelPlatformRepository;
-import com.yju.toonovel.domain.novel.repository.NovelRepository;
-import com.yju.toonovel.domain.novel.repository.PlatformRepository;
 import com.yju.toonovel.domain.user.dto.UserProfileResponseDto;
 import com.yju.toonovel.domain.user.dto.UserRegisterRequestDto;
 import com.yju.toonovel.domain.user.entity.User;


### PR DESCRIPTION
### 📌 개발 개요
- resolve #25 
- 소설 검색 기능 구현
- 조회 기능과 통합
- 정렬 기준 변경(최신순)
  <br>

### 💻  작업 및 변경 사항
- `Genre`
  - `@JsonValue`, `@JsonCreator` 사용하여 직렬화 하였습니다.
- `Novel`
  - 설명과 이미지의 길이를 지정하였습니다.
  - `findAllNovel` 로 검색, 조회 기능을 통합하였습니다.
  - 정렬을 최신순으로 변경하였습니다. 이후 요구 조건이 늘어나면 Sort 방식을 추가하겠습니다.
  <br>

### ✅ Point
- `Genre` 파일의 수정으로 이후 `Review` 도메인 기능 수정이 필요합니다.          
  <br>