### PR TITLE
[FEAT] 추천 시스템 서버와 연결

### DIFF
--- a/src/main/java/com/yju/toonovel/domain/novel/repository/NovelCustomRepository.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/repository/NovelCustomRepository.java
@@ -7,4 +7,6 @@ import com.yju.toonovel.domain.novel.entity.Novel;
 
 public interface NovelCustomRepository {
 	List<Novel> findAllNovel(NovelPaginationRequestDto requestDto);
+
+	List<Novel> findNovelsByNovelIdList(List<Long> novelIds);
 }

--- a/src/main/java/com/yju/toonovel/domain/novel/repository/NovelCustomRepositoryImpl.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/repository/NovelCustomRepositoryImpl.java
@@ -38,6 +38,14 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
 			.fetch();
 	}
 
+	@Override
+	public List<Novel> findNovelsByNovelIdList(List<Long> novelIds) {
+		return jpaQueryFactory
+			.selectFrom(novel)
+			.where(novel.novelId.in(novelIds))
+			.fetch();
+	}
+
 	private BooleanExpression ltNovelId(Long novelId) {
 		if (novelId == null) {
 			return null;

--- a/src/main/java/com/yju/toonovel/domain/recommend/controller/RecommendController.java
+++ b/src/main/java/com/yju/toonovel/domain/recommend/controller/RecommendController.java
@@ -1,0 +1,26 @@
+package com.yju.toonovel.domain.recommend.controller;
+
+import java.util.List;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.yju.toonovel.domain.novel.dto.NovelPaginationResponseDto;
+import com.yju.toonovel.domain.recommend.service.RecommendService;
+import com.yju.toonovel.global.security.jwt.JwtAuthentication;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/recommend")
+@RequiredArgsConstructor
+public class RecommendController {
+	private final RecommendService recommendService;
+
+	@GetMapping
+	public List<NovelPaginationResponseDto> getNovelRecommend(@AuthenticationPrincipal JwtAuthentication user) {
+		return recommendService.getNovelRecommend(user.userId);
+	}
+}

--- a/src/main/java/com/yju/toonovel/domain/recommend/service/RecommendService.java
+++ b/src/main/java/com/yju/toonovel/domain/recommend/service/RecommendService.java
@@ -1,0 +1,57 @@
+package com.yju.toonovel.domain.recommend.service;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.yju.toonovel.domain.novel.dto.NovelPaginationResponseDto;
+import com.yju.toonovel.domain.novel.repository.NovelRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RecommendService {
+
+	private final NovelRepository novelRepository;
+
+	@Value("${server.machineLearning}")
+	private String machineLearningServer;
+
+	@Transactional
+	public List<NovelPaginationResponseDto> getNovelRecommend(Long userId) {
+
+		RestTemplate restTemplate = new RestTemplate();
+
+		URI uri = UriComponentsBuilder
+			.fromUriString(machineLearningServer)
+			.path("/recommend/" + userId)
+			.encode()
+			.build()
+			.toUri();
+
+		Integer[] recommendList = restTemplate.getForObject(uri, Integer[].class);
+
+		List<Long> novelIdList = Optional.ofNullable(recommendList)
+			.map(array -> Arrays.stream(array))
+			.orElseGet(() -> Stream.empty())
+			.map(list -> Long.valueOf(list))
+			.collect(Collectors.toList());
+
+		return novelRepository.findNovelsByNovelIdList(novelIdList)
+			.stream()
+			.map(novel -> NovelPaginationResponseDto.from(novel))
+			.collect(Collectors.toList());
+
+	}
+
+}

--- a/src/main/java/com/yju/toonovel/global/config/WebConfig.java
+++ b/src/main/java/com/yju/toonovel/global/config/WebConfig.java
@@ -1,5 +1,6 @@
 package com.yju.toonovel.global.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
@@ -8,11 +9,19 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @EnableWebMvc
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+	@Value("${server.frontEnd}")
+	private String frontEndServer;
+
+	@Value("${server.backEnd}")
+	private String backEndServer;
+
+	@Value("${server.machineLearning}")
+	private String machineLearningServer;
 
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/**")
-			.allowedOriginPatterns("http://localhost:8080", "http://localhost:3000", "/**")
+			.allowedOriginPatterns(frontEndServer, backEndServer, machineLearningServer, "/**")
 			.allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE")
 			.allowedHeaders("*")
 			.allowCredentials(true);

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -40,6 +40,9 @@ spring:
             user_name_attribute: id
 
 server:
+  frontEnd: ${FRONT_END}
+  backEnd: ${BACK_END}
+  machineLearning: ${MACHINE_LEARNING}
   port: 8080
 
 jwt:


### PR DESCRIPTION
### 📌 개발 개요
- resolve #28 
- FE <-> BE <-> ML 과정을 거칩니다.
  <br>

### 💻  작업 및 변경 사항
- 서버 주소를 환경 변수로 관리
  - 이전 코드 리뷰에서 이야기했던 부분을 반영하였습니다.
- 추천 기능 구현
  - 실제 추천은 ML서버에서 이루어지고, BE서버에서는 받아온 추천 목록을 통해 소설 목록을 조회하고 반환합니다.
  <br>

### ✅ Point
-  [RestTemplate Deprecated?](https://velog.io/@dailylifecoding/Spring-RestTemplate-wont-Deprecate)
- [Deploy BERT for Sentiment Analsysi with FastAPI](https://github.com/curiousily/Deploy-BERT-for-Sentiment-Analysis-with-FastAPI)
- 위 두 링크 읽어보고 코드 작성하였습니다.
  <br>