### PR TITLE
[REFACTOR] '좋아요' 한 작품 리스트 반환 수정

### DIFF
--- a/src/main/java/com/yju/toonovel/domain/novel/dto/LikeNovelPaginationResponseDto.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/dto/LikeNovelPaginationResponseDto.java
@@ -1,0 +1,40 @@
+package com.yju.toonovel.domain.novel.dto;
+
+import com.yju.toonovel.domain.novel.entity.Genre;
+import com.yju.toonovel.domain.novel.entity.LikeNovel;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class LikeNovelPaginationResponseDto {
+
+	private Long likeNovelId;
+	private Long novelId;
+	private String title;
+	private String author;
+	private Genre genre;
+	private String image;
+
+	@Builder
+	public LikeNovelPaginationResponseDto(Long likeNovelId, Long novelId, String title, String author, Genre genre,
+		String image) {
+		this.likeNovelId = likeNovelId;
+		this.novelId = novelId;
+		this.title = title;
+		this.author = author;
+		this.genre = genre;
+		this.image = image;
+	}
+
+	public static LikeNovelPaginationResponseDto from(LikeNovel novel) {
+		return new LikeNovelPaginationResponseDto(
+			novel.getLikeNovelId(),
+			novel.getNovel().getNovelId(),
+			novel.getNovel().getTitle(),
+			novel.getNovel().getAuthor(),
+			novel.getNovel().getGenre(),
+			novel.getNovel().getImage()
+		);
+	}
+}

--- a/src/main/java/com/yju/toonovel/domain/novel/dto/NovelPaginationResponseDto.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/dto/NovelPaginationResponseDto.java
@@ -1,7 +1,6 @@
 package com.yju.toonovel.domain.novel.dto;
 
 import com.yju.toonovel.domain.novel.entity.Genre;
-import com.yju.toonovel.domain.novel.entity.LikeNovel;
 import com.yju.toonovel.domain.novel.entity.Novel;
 
 import lombok.Builder;
@@ -35,13 +34,4 @@ public class NovelPaginationResponseDto {
 		);
 	}
 
-	public static NovelPaginationResponseDto from(LikeNovel novel) {
-		return new NovelPaginationResponseDto(
-			novel.getNovel().getNovelId(),
-			novel.getNovel().getTitle(),
-			novel.getNovel().getAuthor(),
-			novel.getNovel().getGenre(),
-			novel.getNovel().getImage()
-		);
-	}
 }

--- a/src/main/java/com/yju/toonovel/domain/user/controller/UserController.java
+++ b/src/main/java/com/yju/toonovel/domain/user/controller/UserController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.yju.toonovel.domain.novel.dto.NovelPaginationResponseDto;
+import com.yju.toonovel.domain.novel.dto.LikeNovelPaginationResponseDto;
 import com.yju.toonovel.domain.user.dto.UserProfileResponseDto;
 import com.yju.toonovel.domain.user.dto.UserRegisterRequestDto;
 import com.yju.toonovel.domain.user.service.UserService;
@@ -48,7 +48,7 @@ public class UserController {
 	}
 
 	@GetMapping("/novel")
-	public List<NovelPaginationResponseDto> getAllLikeNovel(@AuthenticationPrincipal JwtAuthentication user,
+	public List<LikeNovelPaginationResponseDto> getAllLikeNovel(@AuthenticationPrincipal JwtAuthentication user,
 		@RequestParam Long novelId) {
 		return userService.findAllUserLike(novelId, user.userId);
 	}

--- a/src/main/java/com/yju/toonovel/domain/user/service/UserService.java
+++ b/src/main/java/com/yju/toonovel/domain/user/service/UserService.java
@@ -6,7 +6,7 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.yju.toonovel.domain.novel.dto.NovelPaginationResponseDto;
+import com.yju.toonovel.domain.novel.dto.LikeNovelPaginationResponseDto;
 import com.yju.toonovel.domain.novel.repository.LikeNovelRepository;
 import com.yju.toonovel.domain.user.dto.UserProfileResponseDto;
 import com.yju.toonovel.domain.user.dto.UserRegisterRequestDto;
@@ -52,11 +52,11 @@ public class UserService {
 	}
 
 	@Transactional
-	public List<NovelPaginationResponseDto> findAllUserLike(Long novelId, Long userId) {
+	public List<LikeNovelPaginationResponseDto> findAllUserLike(Long novelId, Long userId) {
 		return likeNovelRepository
 			.findAllUserLikeNovel(userId, novelId)
 			.stream()
-			.map(likenovel -> NovelPaginationResponseDto.from(likenovel))
+			.map(likenovel -> LikeNovelPaginationResponseDto.from(likenovel))
 			.collect(Collectors.toList());
 	}
 


### PR DESCRIPTION
### 📌 개발 개요
- resolve #37 
- FE에서 좋아요 한 작품 리스트를 페이지네이션 하는 과정에서 `likeNovelId`가 필요한 것을 인지하여 추가
  <br>

### 💻  작업 및 변경 사항
- `NovelPaginationResponseDto` 분리
  - `NovelPaginationResponseDto`
  - `LikeNovelPaginationResponseDto`
- 반환 정보에 LikeNovel의 id값도 포함
  <br>

### ✅ Point
- 이전에 꼼꼼하게 신경을 썼어야 하는데 죄송합니다.  더 수정할 사항 있으면 말씀해주세요                  
  <br>