### PR TITLE
[FEAT] API 명세서 작성을 위한 수정

### DIFF
--- a/src/main/java/com/yju/toonovel/domain/novel/controller/NovelController.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/controller/NovelController.java
@@ -2,12 +2,14 @@ package com.yju.toonovel.domain.novel.controller;
 
 import java.util.List;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.yju.toonovel.domain.novel.dto.NovelDetailResponseDto;
@@ -27,16 +29,19 @@ public class NovelController {
 	private final NovelService novelService;
 
 	@GetMapping
+	@ResponseStatus(HttpStatus.OK)
 	public List<NovelPaginationResponseDto> getAllNovel(@ModelAttribute NovelPaginationRequestDto requestDto) {
 		return novelService.findAll(requestDto);
 	}
 
 	@GetMapping("/{novelId}")
+	@ResponseStatus(HttpStatus.OK)
 	public NovelDetailResponseDto getSelectNovel(@PathVariable Long novelId) {
 		return novelService.findById(novelId);
 	}
 
 	@PutMapping("/{novelId}/like")
+	@ResponseStatus(HttpStatus.CREATED)
 	public void toggleLike(
 		@AuthenticationPrincipal JwtAuthentication user,
 		@PathVariable Long novelId
@@ -45,6 +50,7 @@ public class NovelController {
 	}
 
 	@GetMapping("/{novelId}/like")
+	@ResponseStatus(HttpStatus.OK)
 	public UserLikeCheckResponseDto isUserLikes(
 		@AuthenticationPrincipal JwtAuthentication user,
 		@PathVariable long novelId) {

--- a/src/main/java/com/yju/toonovel/domain/recommend/controller/RecommendController.java
+++ b/src/main/java/com/yju/toonovel/domain/recommend/controller/RecommendController.java
@@ -2,10 +2,12 @@ package com.yju.toonovel.domain.recommend.controller;
 
 import java.util.List;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.yju.toonovel.domain.novel.dto.NovelPaginationResponseDto;
@@ -21,11 +23,13 @@ public class RecommendController {
 	private final RecommendService recommendService;
 
 	@GetMapping
+	@ResponseStatus(HttpStatus.OK)
 	public List<NovelPaginationResponseDto> getNovelRecommend(@AuthenticationPrincipal JwtAuthentication user) {
 		return recommendService.getNovelRecommend(user.userId);
 	}
 
 	@PutMapping
+	@ResponseStatus(HttpStatus.CREATED)
 	public void updateRecommendationModel() {
 		recommendService.updateRecommendationModel();
 	}

--- a/src/main/java/com/yju/toonovel/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/yju/toonovel/domain/review/controller/ReviewController.java
@@ -1,6 +1,7 @@
 package com.yju.toonovel.domain.review.controller;
 
 import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -8,6 +9,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.yju.toonovel.domain.review.dto.AllReviewInWorkResponseDto;
@@ -31,6 +33,7 @@ public class ReviewController {
 
 	//리뷰등록
 	@PostMapping
+	@ResponseStatus(HttpStatus.CREATED)
 	public void registerReview(@RequestBody ReviewRegisterRequestDto dto,
 		@AuthenticationPrincipal JwtAuthentication user) {
 		reviewService.reviewRegister(dto, user.userId);
@@ -38,6 +41,7 @@ public class ReviewController {
 
 	//리뷰 삭제
 	@DeleteMapping("/{rid}")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
 	public void deleteReview(@PathVariable("rid") Long rid,
 		@AuthenticationPrincipal JwtAuthentication user) {
 		reviewService.reviewDelete(rid, user.userId);
@@ -45,12 +49,14 @@ public class ReviewController {
 
 	//전체리뷰조회
 	@GetMapping("{page}")
+	@ResponseStatus(HttpStatus.OK)
 	public Page<ReviewAllByUserDto> getAllReviewPaging(@PathVariable("page") int page) {
 		return reviewService.getAllReview(page);
 	}
 
 	//좋아요 등록 기능
 	@PostMapping("/{rid}/like")
+	@ResponseStatus(HttpStatus.CREATED)
 	public void registerReviewLike(@PathVariable("rid") Long rid,
 		@AuthenticationPrincipal JwtAuthentication user) {
 
@@ -59,6 +65,7 @@ public class ReviewController {
 
 	//한작품에 있는 리뷰 전체조회(좋아요까지)
 	@GetMapping("/{nid}/novel")
+	@ResponseStatus(HttpStatus.OK)
 	public Page<AllReviewInWorkResponseDto> reviewAllListWithLike(@PathVariable("nid") Long nid) {
 		Page<AllReviewInWorkResponseDto> reviewAllList = reviewService.getAllReviewWithLike(nid);
 
@@ -67,6 +74,7 @@ public class ReviewController {
 
 	//유저가 작성한 리뷰 조회
 	@GetMapping("/myReview")
+	@ResponseStatus(HttpStatus.OK)
 	public Page<ReviewAllByUserDto> getAllReviewByUser(@AuthenticationPrincipal JwtAuthentication user) {
 		Page<ReviewAllByUserDto> reviewList = reviewService.getAllReviewByUser(user.userId);
 

--- a/src/main/java/com/yju/toonovel/domain/user/controller/UserController.java
+++ b/src/main/java/com/yju/toonovel/domain/user/controller/UserController.java
@@ -2,6 +2,7 @@ package com.yju.toonovel.domain.user.controller;
 
 import java.util.List;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.yju.toonovel.domain.novel.dto.LikeNovelPaginationResponseDto;
@@ -27,27 +29,32 @@ public class UserController {
 	private final UserService userService;
 
 	@GetMapping("/{userId}")
+	@ResponseStatus(HttpStatus.OK)
 	public UserProfileResponseDto getUserProfile(@PathVariable Long userId) {
 		return userService.getUserProfile(userId);
 	}
 
 	@GetMapping("/me")
+	@ResponseStatus(HttpStatus.OK)
 	public UserProfileResponseDto getMyProfile(@AuthenticationPrincipal JwtAuthentication user) {
 		return userService.getUserProfile(user.userId);
 	}
 
 	@DeleteMapping("/me")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
 	public void deleteUser(@AuthenticationPrincipal JwtAuthentication user) {
 		userService.deleteUser(user.userId);
 	}
 
 	@PatchMapping("/register")
+	@ResponseStatus(HttpStatus.CREATED)
 	public void userRegister(@RequestBody UserRegisterRequestDto requestDto,
 		@AuthenticationPrincipal JwtAuthentication user) {
 		userService.register(user.userId, requestDto);
 	}
 
 	@GetMapping("/novel")
+	@ResponseStatus(HttpStatus.OK)
 	public List<LikeNovelPaginationResponseDto> getAllLikeNovel(@AuthenticationPrincipal JwtAuthentication user,
 		@RequestParam Long novelId) {
 		return userService.findAllUserLike(novelId, user.userId);

--- a/src/main/java/com/yju/toonovel/global/common/Sort.java
+++ b/src/main/java/com/yju/toonovel/global/common/Sort.java
@@ -1,0 +1,26 @@
+package com.yju.toonovel.global.common;
+
+import com.querydsl.core.types.Order;
+
+public enum Sort {
+	CREATED_DATE_DESC("createdDate", Order.DESC),
+	CREATED_DATE_ASC("createdDate", Order.ASC),
+	REVIEW_LIKE_DESC("reviewLike", Order.DESC);
+
+	private final String property;
+	private final Order order;
+
+	Sort(String property, Order order) {
+		this.property = property;
+		this.order = order;
+	}
+
+	public String getProperty() {
+		return property;
+	}
+
+	public Order getOrder() {
+		return order;
+	}
+
+}


### PR DESCRIPTION
### 📌 개발 개요
- resolve #42 
- FE 요청에 따라 정렬 기준을 추가하고, 이후에 추가하기 편하게 개선하였습니다.
- ResponseStatus를 반환하도록 수정하고, Postman 으로 API 명세를 공유하였습니다.
  <br>

### 💻  작업 및 변경 사항
- `PostController`를 제외한 모든 Controller에 `@ResponseStatus`를 추가하였습니다.
  - Get : 200
  - Put, Patch, Post : 201
  - Delete : 204
- `Sort` 를 `Enum` 클래스로 관리하도록 합니다.
  - 현재는 최신 순, 오래된 순, 인기 리뷰 순을 추가한 상태입니다.
  각 작업하시면서 추가하여 사용하시면 되겠습니다.
  <br>

### ✅ Point
- 사소한 변경이지만, 우선 작업해서 반영해 두면 뒤 작업이 편할 것 같아서 작은 단위로 이슈를 만들고 PR을 올렸습니다.
- 기존 조회 `Dto`에 `Sort`를 추가하고, 각 조회에 반영하시면 될 것 같습니다.        
  <br>