### PR TITLE
[REFACTOR] Review 도메인 리팩토링

### DIFF
--- a/src/main/java/com/yju/toonovel/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/yju/toonovel/domain/review/controller/ReviewController.java
@@ -77,8 +77,9 @@ public class ReviewController {
 	//유저가 작성한 리뷰 조회
 	@GetMapping("/myReview")
 	@ResponseStatus(HttpStatus.OK)
-	public Page<ReviewAllByUserDto> getAllReviewByUser(@AuthenticationPrincipal JwtAuthentication user) {
-		Page<ReviewAllByUserDto> reviewList = reviewService.getAllReviewByUser(user.userId);
+	public Page<ReviewAllByUserDto> getAllReviewByUser(@AuthenticationPrincipal JwtAuthentication user,
+		@ModelAttribute ReviewPaginationRequestDto requestDto) {
+		Page<ReviewAllByUserDto> reviewList = reviewService.getAllReviewByUser(user.userId, requestDto);
 
 		return reviewList;
 	}

--- a/src/main/java/com/yju/toonovel/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/yju/toonovel/domain/review/controller/ReviewController.java
@@ -82,11 +82,4 @@ public class ReviewController {
 
 		return reviewList;
 	}
-
-	//장르별 전체리뷰조회
-	// @GetMapping("/{genre}/genre")
-	// public Page<ReviewAllByUserDto> getAllReviewWhereGenre(@PathVariable("genre") String genre) {
-	//
-	// 	return reviewService.getAllReviewWhereGenre(genre);
-	// }
 }

--- a/src/main/java/com/yju/toonovel/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/yju/toonovel/domain/review/controller/ReviewController.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.yju.toonovel.domain.review.dto.AllReviewInWorkResponseDto;
 import com.yju.toonovel.domain.review.dto.ReviewAllByUserDto;
+import com.yju.toonovel.domain.review.dto.ReviewPaginationRequestDto;
 import com.yju.toonovel.domain.review.dto.ReviewRegisterRequestDto;
 import com.yju.toonovel.domain.review.service.LikeReviewService;
 import com.yju.toonovel.domain.review.service.ReviewService;
@@ -48,10 +50,10 @@ public class ReviewController {
 	}
 
 	//전체리뷰조회
-	@GetMapping("{page}")
+	@GetMapping()
 	@ResponseStatus(HttpStatus.OK)
-	public Page<ReviewAllByUserDto> getAllReviewPaging(@PathVariable("page") int page) {
-		return reviewService.getAllReview(page);
+	public Page<ReviewAllByUserDto> getAllReviewPaging(@ModelAttribute ReviewPaginationRequestDto requestDto) {
+		return reviewService.getAllReview(requestDto);
 	}
 
 	//좋아요 등록 기능

--- a/src/main/java/com/yju/toonovel/domain/review/dto/ReviewPaginationRequestDto.java
+++ b/src/main/java/com/yju/toonovel/domain/review/dto/ReviewPaginationRequestDto.java
@@ -1,0 +1,24 @@
+package com.yju.toonovel.domain.review.dto;
+
+import com.yju.toonovel.domain.novel.entity.Genre;
+import com.yju.toonovel.global.common.Sort;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ReviewPaginationRequestDto {
+
+	private int page;
+	private int limit;
+	private Genre genre;
+	private Sort sort;
+
+	@Builder
+	public ReviewPaginationRequestDto(int page, int limit, Genre genre, Sort sort) {
+		this.page = page;
+		this.genre = genre;
+		this.limit = limit;
+		this.sort = sort == null ? sort.CREATED_DATE_DESC : sort;
+	}
+}

--- a/src/main/java/com/yju/toonovel/domain/review/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/com/yju/toonovel/domain/review/repository/ReviewRepositoryCustom.java
@@ -1,9 +1,12 @@
 package com.yju.toonovel.domain.review.repository;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import com.yju.toonovel.domain.review.dto.ReviewAllByUserDto;
+import com.yju.toonovel.domain.review.dto.ReviewPaginationRequestDto;
 
 public interface ReviewRepositoryCustom {
 

--- a/src/main/java/com/yju/toonovel/domain/review/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/com/yju/toonovel/domain/review/repository/ReviewRepositoryCustom.java
@@ -12,7 +12,7 @@ import com.yju.toonovel.domain.review.dto.ReviewPaginationRequestDto;
 public interface ReviewRepositoryCustom {
 
 	//유저가 작성한 리뷰조회
-	Page<ReviewAllByUserDto> findAllReviewByUser(Long uid, Pageable pageable);
+	Page<ReviewAllByUserDto> findAllReviewByUser(Long uid, Pageable pageable, ReviewPaginationRequestDto requestDto);
 
 	//전체리뷰조회
 	Page<ReviewAllByUserDto> getAllReview(Pageable pageable, ReviewPaginationRequestDto requestDto);

--- a/src/main/java/com/yju/toonovel/domain/review/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/com/yju/toonovel/domain/review/repository/ReviewRepositoryCustom.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import com.yju.toonovel.domain.review.dto.AllReviewInWorkResponseDto;
 import com.yju.toonovel.domain.review.dto.ReviewAllByUserDto;
 import com.yju.toonovel.domain.review.dto.ReviewPaginationRequestDto;
 
@@ -14,15 +15,6 @@ public interface ReviewRepositoryCustom {
 	Page<ReviewAllByUserDto> findAllReviewByUser(Long uid, Pageable pageable);
 
 	//전체리뷰조회
-	Page<ReviewAllByUserDto> getAllReview(Pageable pageable);
-
-	//장르별 전체리뷰조회
-	// Page<ReviewAllByUserDto> getAllReviewWhereGenre(String genre, Pageable pageable);
-
-	//전체리뷰조회 - 좋아요순 정렬
-	Page<ReviewAllByUserDto> getAllReviewOrderByLike(Pageable pageable);
-
-	//장르별 전체리뷰조회 - 좋아요순 정렬
-	// Page<ReviewAllByUserDto> getAllReviewOrderByLikeWhereGenre(String genre, Pageable pageable);
+	Page<ReviewAllByUserDto> getAllReview(Pageable pageable, ReviewPaginationRequestDto requestDto);
 }
 

--- a/src/main/java/com/yju/toonovel/domain/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/yju/toonovel/domain/review/repository/ReviewRepositoryImpl.java
@@ -1,24 +1,37 @@
 package com.yju.toonovel.domain.review.repository;
 
+import static com.yju.toonovel.domain.novel.entity.QNovel.*;
+import static com.yju.toonovel.domain.review.entity.QReview.*;
+
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.QBean;
+import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.yju.toonovel.domain.novel.entity.Genre;
 import com.yju.toonovel.domain.review.dto.ReviewAllByUserDto;
 import com.yju.toonovel.domain.review.entity.QReview;
+import com.yju.toonovel.domain.review.entity.Review;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Repository
 @RequiredArgsConstructor
+@Slf4j
 public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
 	private final JPAQueryFactory queryFactory;
 
@@ -40,6 +53,46 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
 		);
 	}
 
+	private OrderSpecifier<?> getOrderSpecifiers(Pageable pageable) {
+												//sort sort
+
+		List<OrderSpecifier> orders = new ArrayList<>();
+
+		for (Sort.Order order : pageable.getSort()) {
+			Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
+			String prop = order.getProperty();
+			PathBuilder orderByExpression = new PathBuilder(Review.class, "review");
+
+			orders.add(new OrderSpecifier(direction, orderByExpression.get(prop)));
+		}
+		return orders.get(0);
+
+		// List<OrderSpecifier> orders = new ArrayList<>();
+		//
+		// for (Sort.Order order : pageable.getSort()) {
+		// 	Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
+		// 	String prop = order.getProperty();
+		// 	PathBuilder orderByExpression = new PathBuilder(Review.class, "review");
+		//
+		// 	orders.add(new OrderSpecifier(direction, orderByExpression.get(prop)));
+		// }
+		// return orders;
+	}
+
+	private Predicate eqGenre(Genre genre) {
+		if (genre == null) {
+			return null;
+		}
+		return novel.genre.eq(genre);
+	}
+
+	private Predicate eqUserId(Long userId) {
+		if (userId == null) {
+			return null;
+		}
+		return review.writer.userId.eq(userId);
+	}
+
 	//유저가 작성한 리뷰조회
 	@Override
 	public Page<ReviewAllByUserDto> findAllReviewByUser(Long uid, Pageable pageable) {
@@ -48,7 +101,7 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
 		JPAQuery<ReviewAllByUserDto> results = queryFactory
 			.select(reviewSelect(review))
 			.from(review)
-			.where(review.writer.userId.eq(uid))
+			.where(eqUserId(uid))
 			.orderBy(review.createdDate.desc())
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize());
@@ -61,12 +114,13 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
 	//전체리뷰조회
 	@Override
 	public Page<ReviewAllByUserDto> getAllReview(Pageable pageable) {
+		log.info("test : " + pageable.getSort());
 		QReview review = QReview.review;
 
 		JPQLQuery<ReviewAllByUserDto> results = queryFactory
 			.select(reviewSelect(review))
 			.from(review)
-			.orderBy(review.createdDate.desc())
+			.orderBy(getOrderSpecifiers(pageable))
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize());
 

--- a/src/main/java/com/yju/toonovel/domain/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/yju/toonovel/domain/review/repository/ReviewRepositoryImpl.java
@@ -81,14 +81,15 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
 
 	//유저가 작성한 리뷰조회
 	@Override
-	public Page<ReviewAllByUserDto> findAllReviewByUser(Long uid, Pageable pageable) {
+	public Page<ReviewAllByUserDto> findAllReviewByUser(Long uid, Pageable pageable,
+			ReviewPaginationRequestDto requestDto) {
 		QReview review = QReview.review;
 
 		JPAQuery<ReviewAllByUserDto> results = queryFactory
 			.select(reviewSelect(review))
 			.from(review)
 			.where(eqUserId(uid))
-			.orderBy(review.createdDate.desc())
+			.orderBy(getOrderSpecifiers(requestDto.getSort()))
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize());
 
@@ -116,6 +117,7 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
 	}
 
 	//ReviewRepository  -> 한 작품에 대한 전체 리뷰 + 로그인 한 유저가 좋아요 한 부분까지 조회, querydsl변환
+	//반환하는 dto 다른부분 때문에 변환하기 애매해 주석처리 추후 논의 필요
 	// public Page<AllReviewInWorkResponseDto> getReviewByUser(Pageable pageable,
 	// ReviewPaginationRequestDto requestDto, Long nid) {
 	// 	QReview review = QReview.review;

--- a/src/main/java/com/yju/toonovel/domain/review/service/ReviewService.java
+++ b/src/main/java/com/yju/toonovel/domain/review/service/ReviewService.java
@@ -3,7 +3,6 @@ package com.yju.toonovel.domain.review.service;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -55,23 +54,9 @@ public class ReviewService {
 
 	//전체 리뷰 조회
 	public Page<ReviewAllByUserDto> getAllReview(ReviewPaginationRequestDto requestDto) {
-		Pageable pageable = PageRequest.of(requestDto.getPage(), requestDto.getLimit(), sortBy(requestDto));
-
-		return reviewRepositoryImpl.getAllReview(pageable);
+		Pageable pageable = PageRequest.of(requestDto.getPage(), requestDto.getLimit());
+		return reviewRepositoryImpl.getAllReview(pageable, requestDto);
 	}
-
-	private Sort sortBy(ReviewPaginationRequestDto requestDto) {
-		return Sort.by(requestDto.getSortDirection(), requestDto.getSortBy());
-	}
-
-	//장르별 전체리뷰조회
-	// public Page<ReviewAllByUserDto> getAllReviewWhereGenre(String genre) {
-	// 	String novel = novelRepository.findByGenre(genre)
-	// 		.orElseThrow(() -> new GenreNotFoundException());
-	//
-	// 	Pageable pageable = PageRequest.of(0, 10);
-	// 	return reviewRepositoryImpl.getAllReviewWhereGenre(novel, pageable);
-	// }
 
 	//리뷰 삭제
 	@Transactional
@@ -86,7 +71,6 @@ public class ReviewService {
 	}
 
 	// 이미 추천했다라는것 - 진입했을때 알필요 x
-
 	public void validateDelete(Long userId, Long reviewId) {
 		Review review = reviewRepository.deleteReviewByReviewIdAndUserId(reviewId)
 			.orElseThrow(() -> new ReviewNotFoundException());

--- a/src/main/java/com/yju/toonovel/domain/review/service/ReviewService.java
+++ b/src/main/java/com/yju/toonovel/domain/review/service/ReviewService.java
@@ -94,9 +94,9 @@ public class ReviewService {
 	}
 
 	//유저가 작성한 리뷰 조회
-	public Page<ReviewAllByUserDto> getAllReviewByUser(Long uid) {
-		Pageable pageable = PageRequest.of(0, 10);
-		Page<ReviewAllByUserDto> reviewList = reviewRepositoryImpl.findAllReviewByUser(uid, pageable);
+	public Page<ReviewAllByUserDto> getAllReviewByUser(Long uid, ReviewPaginationRequestDto requestDto) {
+		Pageable pageable = PageRequest.of(requestDto.getPage(), requestDto.getLimit());
+		Page<ReviewAllByUserDto> reviewList = reviewRepositoryImpl.findAllReviewByUser(uid, pageable, requestDto);
 
 		return reviewList;
 	}

--- a/src/main/java/com/yju/toonovel/domain/review/service/ReviewService.java
+++ b/src/main/java/com/yju/toonovel/domain/review/service/ReviewService.java
@@ -3,6 +3,7 @@ package com.yju.toonovel.domain.review.service;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,6 +12,7 @@ import com.yju.toonovel.domain.novel.exception.NovelNotFoundException;
 import com.yju.toonovel.domain.novel.repository.NovelRepository;
 import com.yju.toonovel.domain.review.dto.AllReviewInWorkResponseDto;
 import com.yju.toonovel.domain.review.dto.ReviewAllByUserDto;
+import com.yju.toonovel.domain.review.dto.ReviewPaginationRequestDto;
 import com.yju.toonovel.domain.review.dto.ReviewRegisterRequestDto;
 import com.yju.toonovel.domain.review.entity.Review;
 import com.yju.toonovel.domain.review.exception.DuplicateReviewException;
@@ -52,9 +54,14 @@ public class ReviewService {
 	}
 
 	//전체 리뷰 조회
-	public Page<ReviewAllByUserDto> getAllReview(int page) {
-		Pageable pageable = PageRequest.of(page, 10);
+	public Page<ReviewAllByUserDto> getAllReview(ReviewPaginationRequestDto requestDto) {
+		Pageable pageable = PageRequest.of(requestDto.getPage(), requestDto.getLimit(), sortBy(requestDto));
+
 		return reviewRepositoryImpl.getAllReview(pageable);
+	}
+
+	private Sort sortBy(ReviewPaginationRequestDto requestDto) {
+		return Sort.by(requestDto.getSortDirection(), requestDto.getSortBy());
 	}
 
 	//장르별 전체리뷰조회


### PR DESCRIPTION
### 📌 개발 개요
- resolve #41 
  <br>

### 💻  작업 및 변경 사항
- 리뷰 전체 조회 할 때, 정렬기준 및 장르별 조회를 위한 동적쿼리 기능 구현
-  ReviewPaginationRequestDto 통해 숫자 페이징 및 동적쿼리에서 사용할 정렬기준, 장르를 받습니다.
- getOrderSpecifiers메서드를 통해 사용자가 url에 보내준 정렬 기준을 가져와 order by해줍니다.
  <br>

### ✅ Point
- 하나의 작품에 해당되는 리뷰를 조회할 때 사용되는 dto와 전체 리뷰 조회할 때 사용되는 dto가 다르다 보니, 일단은 주석 처리 해두었습니다
- 만약 하나의 작품에 해당되는 리뷰를 조회한다면, 중복 코드 제거를 위해 따로 빼두었던 reviewSelect를 하나의 작품에 해당되는 리뷰를 조회하는 dto를 사용할 수 있도록 하나 더 만들어야 하는데 이게 맞는 것일지, 아니면 따로 빼두지 않고 메서드 안에다가 원래대로 넣을지 고민이 됩니다.           
  <br>