### PR TITLE
[FEAT] Novel 도메인 기능 추가

### DIFF
--- a/src/main/java/com/yju/toonovel/domain/novel/dto/LikeNovelPaginationResponseDto.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/dto/LikeNovelPaginationResponseDto.java
@@ -14,12 +14,12 @@ public class LikeNovelPaginationResponseDto {
 	private String title;
 	private String author;
 	private Genre genre;
-	private Integer grade;
+	private Double grade;
 	private String image;
 
 	@Builder
 	public LikeNovelPaginationResponseDto(Long likeNovelId, Long novelId, String title, String author, Genre genre,
-		Integer grade, String image) {
+		Double grade, String image) {
 		this.likeNovelId = likeNovelId;
 		this.novelId = novelId;
 		this.title = title;

--- a/src/main/java/com/yju/toonovel/domain/novel/dto/LikeNovelPaginationResponseDto.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/dto/LikeNovelPaginationResponseDto.java
@@ -14,16 +14,18 @@ public class LikeNovelPaginationResponseDto {
 	private String title;
 	private String author;
 	private Genre genre;
+	private Integer grade;
 	private String image;
 
 	@Builder
 	public LikeNovelPaginationResponseDto(Long likeNovelId, Long novelId, String title, String author, Genre genre,
-		String image) {
+		Integer grade, String image) {
 		this.likeNovelId = likeNovelId;
 		this.novelId = novelId;
 		this.title = title;
 		this.author = author;
 		this.genre = genre;
+		this.grade = grade;
 		this.image = image;
 	}
 
@@ -34,6 +36,7 @@ public class LikeNovelPaginationResponseDto {
 			novel.getNovel().getTitle(),
 			novel.getNovel().getAuthor(),
 			novel.getNovel().getGenre(),
+			novel.getNovel().getGrade(),
 			novel.getNovel().getImage()
 		);
 	}

--- a/src/main/java/com/yju/toonovel/domain/novel/dto/NovelDetailResponseDto.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/dto/NovelDetailResponseDto.java
@@ -20,7 +20,7 @@ public class NovelDetailResponseDto {
 	private String author;
 	private Genre genre;
 	private long likeCount;
-	private Integer grade;
+	private Double grade;
 	private List<PlatformResponseDto> platforms = new ArrayList<>();
 	private String image;
 

--- a/src/main/java/com/yju/toonovel/domain/novel/dto/NovelDetailResponseDto.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/dto/NovelDetailResponseDto.java
@@ -20,6 +20,7 @@ public class NovelDetailResponseDto {
 	private String author;
 	private Genre genre;
 	private long likeCount;
+	private Integer grade;
 	private List<PlatformResponseDto> platforms = new ArrayList<>();
 	private String image;
 
@@ -30,6 +31,7 @@ public class NovelDetailResponseDto {
 		this.author = novel.getAuthor();
 		this.genre = novel.getGenre();
 		this.likeCount = novel.getLikeCount();
+		this.grade = novel.getGrade();
 		platform.forEach(
 			idx -> this.platforms.add(new PlatformResponseDto(idx))
 		);

--- a/src/main/java/com/yju/toonovel/domain/novel/dto/NovelPaginationRequestDto.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/dto/NovelPaginationRequestDto.java
@@ -1,6 +1,7 @@
 package com.yju.toonovel.domain.novel.dto;
 
 import com.yju.toonovel.domain.novel.entity.Genre;
+import com.yju.toonovel.global.common.Sort;
 
 import lombok.Getter;
 
@@ -11,12 +12,14 @@ public class NovelPaginationRequestDto {
 	private String title;
 	private String author;
 	private Genre genre;
+	private Sort sort;
 
-	public NovelPaginationRequestDto(Long novelId, String title, String author, Genre genre) {
+	public NovelPaginationRequestDto(Long novelId, String title, String author, Genre genre, Sort sort) {
 		this.novelId = novelId;
 		this.title = title;
 		this.author = author;
 		this.genre = genre;
+		this.sort = sort == null ? Sort.CREATED_DATE_DESC : sort;
 	}
 
 }

--- a/src/main/java/com/yju/toonovel/domain/novel/dto/NovelPaginationResponseDto.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/dto/NovelPaginationResponseDto.java
@@ -13,11 +13,11 @@ public class NovelPaginationResponseDto {
 	private String title;
 	private String author;
 	private Genre genre;
-	private Integer grade;
+	private Double grade;
 	private String image;
 
 	@Builder
-	public NovelPaginationResponseDto(Long novelId, String title, String author, Genre genre, Integer grade,
+	public NovelPaginationResponseDto(Long novelId, String title, String author, Genre genre, Double grade,
 		String image) {
 		this.novelId = novelId;
 		this.title = title;

--- a/src/main/java/com/yju/toonovel/domain/novel/dto/NovelPaginationResponseDto.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/dto/NovelPaginationResponseDto.java
@@ -13,14 +13,17 @@ public class NovelPaginationResponseDto {
 	private String title;
 	private String author;
 	private Genre genre;
+	private Integer grade;
 	private String image;
 
 	@Builder
-	public NovelPaginationResponseDto(Long novelId, String title, String author, Genre genre, String image) {
+	public NovelPaginationResponseDto(Long novelId, String title, String author, Genre genre, Integer grade,
+		String image) {
 		this.novelId = novelId;
 		this.title = title;
 		this.author = author;
 		this.genre = genre;
+		this.grade = grade;
 		this.image = image;
 	}
 
@@ -30,6 +33,7 @@ public class NovelPaginationResponseDto {
 			novel.getTitle(),
 			novel.getAuthor(),
 			novel.getGenre(),
+			novel.getGrade(),
 			novel.getImage()
 		);
 	}

--- a/src/main/java/com/yju/toonovel/domain/novel/entity/Novel.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/entity/Novel.java
@@ -47,6 +47,10 @@ public class Novel extends BaseEntity {
 	@Formula("(select count(1) from like_novel l where l.novel_id = novel_id and l.is_actived = true)")
 	private long likeCount;
 
+	@Basic(fetch = FetchType.LAZY)
+	@Formula("(select AVG(r.review_grade) from review r where r.novel_id = novel_id)")
+	private Integer grade;
+
 	@OneToMany(mappedBy = "novel")
 	private List<NovelPlatform> novelPlatforms = new ArrayList<>();
 

--- a/src/main/java/com/yju/toonovel/domain/novel/entity/Novel.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/entity/Novel.java
@@ -44,12 +44,12 @@ public class Novel extends BaseEntity {
 	private Genre genre;
 
 	@Basic(fetch = FetchType.LAZY)
-	@Formula("(select count(1) from like_novel l where l.novel_id = novel_id and l.is_actived = true)")
+	@Formula("(SELECT COUNT(1) FROM like_novel l WHERE l.novel_id = novel_id and l.is_actived = true)")
 	private long likeCount;
 
 	@Basic(fetch = FetchType.LAZY)
-	@Formula("(select AVG(r.review_grade) from review r where r.novel_id = novel_id)")
-	private Integer grade;
+	@Formula("(SELECT FORMAT(AVG(r.review_grade), 1) FROM review r WHERE r.novel_id = novel_id)")
+	private Double grade;
 
 	@OneToMany(mappedBy = "novel")
 	private List<NovelPlatform> novelPlatforms = new ArrayList<>();

--- a/src/main/java/com/yju/toonovel/domain/novel/repository/NovelCustomRepositoryImpl.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/repository/NovelCustomRepositoryImpl.java
@@ -6,12 +6,16 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Path;
 import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.yju.toonovel.domain.novel.dto.NovelPaginationRequestDto;
 import com.yju.toonovel.domain.novel.entity.Genre;
 import com.yju.toonovel.domain.novel.entity.Novel;
+import com.yju.toonovel.global.common.Sort;
 
 import lombok.RequiredArgsConstructor;
 
@@ -33,7 +37,7 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
 			)
 			.limit(30)
 			.orderBy(
-				novel.novelId.desc()
+				getOrderSpecifier(requestDto.getSort())
 			)
 			.fetch();
 	}
@@ -75,4 +79,14 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
 		return novel.author.contains(author);
 	}
 
+	private OrderSpecifier getOrderSpecifier(Sort sort) {
+		for (Sort value : Sort.values()) {
+			if (sort == value) {
+				Path<Object> path = Expressions.path(Object.class, novel, value.getProperty()
+				);
+				return new OrderSpecifier(value.getOrder(), path);
+			}
+		}
+		return null;
+	}
 }

--- a/src/main/java/com/yju/toonovel/domain/review/entity/Review.java
+++ b/src/main/java/com/yju/toonovel/domain/review/entity/Review.java
@@ -1,6 +1,6 @@
 package com.yju.toonovel.domain.review.entity;
 
-import javax.persistence.CascadeType;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -9,7 +9,6 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 
-import org.aspectj.weaver.GeneratedReferenceTypeDelegate;
 import org.hibernate.annotations.ColumnDefault;
 
 import com.yju.toonovel.domain.novel.entity.Novel;
@@ -33,6 +32,8 @@ public class Review extends BaseEntity {
 
 	@ColumnDefault(value = "0")
 	private int reviewLike;
+
+	@Column(nullable = false)
 	private int reviewGrade;
 
 	@ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/yju/toonovel/domain/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/yju/toonovel/domain/review/repository/ReviewRepositoryImpl.java
@@ -3,7 +3,6 @@ package com.yju.toonovel.domain.review.repository;
 import static com.yju.toonovel.domain.novel.entity.QNovel.*;
 import static com.yju.toonovel.domain.review.entity.QReview.*;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
@@ -82,7 +81,7 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
 	//유저가 작성한 리뷰조회
 	@Override
 	public Page<ReviewAllByUserDto> findAllReviewByUser(Long uid, Pageable pageable,
-			ReviewPaginationRequestDto requestDto) {
+		ReviewPaginationRequestDto requestDto) {
 		QReview review = QReview.review;
 
 		JPAQuery<ReviewAllByUserDto> results = queryFactory

--- a/src/main/java/com/yju/toonovel/global/common/Sort.java
+++ b/src/main/java/com/yju/toonovel/global/common/Sort.java
@@ -5,7 +5,8 @@ import com.querydsl.core.types.Order;
 public enum Sort {
 	CREATED_DATE_DESC("createdDate", Order.DESC),
 	CREATED_DATE_ASC("createdDate", Order.ASC),
-	REVIEW_LIKE_DESC("reviewLike", Order.DESC);
+	REVIEW_LIKE_DESC("reviewLike", Order.DESC),
+	NOVEL_GRADE_DESC("grade", Order.DESC);
 
 	private final String property;
 	private final Order order;


### PR DESCRIPTION
### 📌 개발 개요
- resolve #45 
- 이전에 해당 작품에 달린 Review의 평균 값(평점)을 알 수 있는 기능을 추가하지 않았었는데, 이번에 추가하였습니다.
단건 조회나 전체 조회에서 작품 별 평점을 확인 할 수 있도록 하고, 평점을 기준으로(높은 순) 조회하는 기능을 추가하였습니다.
  <br>

### 💻  작업 및 변경 사항
- 모든 ResponseDto에 grade(평점)을 반환하도록 추가 하였습니다.
- 전체 조회 요청 시 Sort기준으로 평점 순을 요청할 수 있도록 하였습니다.
  - `sort=NOVEL_GRADE_DESC`
  - 지정하지 않으면 최신 작품 순으로 정렬하도록 하였습니다.
  <br>

### ✅ Point
- `Review` 엔티티의 평점 부분을 notnull 처리 하였습니다. 
- ReviewGrade가 int형이라 Novel의 grade도 Integer로 하였습니다.
- 주말 동안의 작업으로 기존에 FE에서 작업한 부분에서 조금 변경이 필요합니다.. 
  <br>