### PR TITLE
[FEAT] User 도메인 validation 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,8 @@ repositories {
 dependencies {
     // Web
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    // validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     // Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
@@ -75,6 +77,7 @@ sourceSets {
 // querydsl 컴파일 옵션
 compileQuerydsl {
     options.annotationProcessorPath = configurations.querydsl
+    classpath = sourceSets.main.runtimeClasspath + configurations.querydsl
 }
 
 // querydsl 이 compileClassPath 상속

--- a/src/main/java/com/yju/toonovel/domain/user/controller/UserController.java
+++ b/src/main/java/com/yju/toonovel/domain/user/controller/UserController.java
@@ -2,6 +2,8 @@ package com.yju.toonovel.domain.user.controller;
 
 import java.util.List;
 
+import javax.validation.Valid;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -46,11 +48,11 @@ public class UserController {
 		userService.deleteUser(user.userId);
 	}
 
-	@PatchMapping("/register")
+	@PatchMapping()
 	@ResponseStatus(HttpStatus.CREATED)
-	public void userRegister(@RequestBody UserRegisterRequestDto requestDto,
+	public void updateUser(@RequestBody @Valid UserRegisterRequestDto requestDto,
 		@AuthenticationPrincipal JwtAuthentication user) {
-		userService.register(user.userId, requestDto);
+		userService.updateUser(user.userId, requestDto);
 	}
 
 	@GetMapping("/novel")

--- a/src/main/java/com/yju/toonovel/domain/user/controller/UserController.java
+++ b/src/main/java/com/yju/toonovel/domain/user/controller/UserController.java
@@ -48,7 +48,7 @@ public class UserController {
 		userService.deleteUser(user.userId);
 	}
 
-	@PatchMapping()
+	@PatchMapping("/me")
 	@ResponseStatus(HttpStatus.CREATED)
 	public void updateUser(@RequestBody @Valid UserRegisterRequestDto requestDto,
 		@AuthenticationPrincipal JwtAuthentication user) {

--- a/src/main/java/com/yju/toonovel/domain/user/dto/UserRegisterRequestDto.java
+++ b/src/main/java/com/yju/toonovel/domain/user/dto/UserRegisterRequestDto.java
@@ -1,5 +1,10 @@
 package com.yju.toonovel.domain.user.dto;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+import org.hibernate.validator.constraints.Length;
+
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,17 +13,21 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class UserRegisterRequestDto {
 
+	@Length(max = 15)
+	@NotBlank
 	private String nickname;
+	@NotBlank
 	private String gender;
+	@NotBlank
+	@Pattern(regexp = "(19|20)\\d{2}\\-(0[1-9]|1[012])\\-(0[1-9]|[12][0-9]|3[01])")
 	private String birth;
-	private String userId;
+
 
 	@Builder
-	public UserRegisterRequestDto(String nickname, String gender, String birth, String userId) {
+	public UserRegisterRequestDto(String nickname, String gender, String birth) {
 		this.nickname = nickname;
 		this.gender = gender;
 		this.birth = birth;
-		this.userId = userId;
 	}
 
 }

--- a/src/main/java/com/yju/toonovel/domain/user/entity/User.java
+++ b/src/main/java/com/yju/toonovel/domain/user/entity/User.java
@@ -20,6 +20,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @Entity
+@Where(clause = "deleted = false")
+@SQLDelete(sql = "UPDATE user SET deleted = true where user_id=?")
 public class User extends BaseEntity {
 
 	@Id
@@ -48,6 +50,9 @@ public class User extends BaseEntity {
 
 	@Column(length = 10)
 	private String birth;
+
+	@Column(nullable = false)
+	private boolean deleted;
 
 	@Builder
 	public User(String nickname, String imageUrl, Provider provider, String oauthId,

--- a/src/main/java/com/yju/toonovel/domain/user/entity/User.java
+++ b/src/main/java/com/yju/toonovel/domain/user/entity/User.java
@@ -8,6 +8,9 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
 import com.yju.toonovel.global.common.entity.BaseEntity;
 
 import lombok.Builder;
@@ -23,8 +26,10 @@ public class User extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long userId;
 
+	@Column(length = 15)
 	private String nickname;
 
+	@Column(length = 1024)
 	private String imageUrl;
 
 	@Enumerated(EnumType.STRING)
@@ -38,8 +43,10 @@ public class User extends BaseEntity {
 	@Column(nullable = false)
 	private Role role;
 
+	@Column(length = 5)
 	private String gender;
 
+	@Column(length = 10)
 	private String birth;
 
 	@Builder

--- a/src/main/java/com/yju/toonovel/domain/user/entity/User.java
+++ b/src/main/java/com/yju/toonovel/domain/user/entity/User.java
@@ -66,7 +66,7 @@ public class User extends BaseEntity {
 		this.birth = birth;
 	}
 
-	public void register(String nickname, String gender, String birth) {
+	public void update(String nickname, String gender, String birth) {
 		this.nickname = nickname;
 		this.gender = gender;
 		this.birth = birth;

--- a/src/main/java/com/yju/toonovel/domain/user/service/UserService.java
+++ b/src/main/java/com/yju/toonovel/domain/user/service/UserService.java
@@ -34,7 +34,7 @@ public class UserService {
 	public void updateUser(Long id, UserRegisterRequestDto requestDto) {
 		User user = userRepository.findByUserId(id)
 			.orElseThrow(() -> new UserNotFoundException());
-		user.register(requestDto.getNickname(), requestDto.getGender(), requestDto.getBirth());
+		user.update(requestDto.getNickname(), requestDto.getGender(), requestDto.getBirth());
 	}
 
 	@Transactional

--- a/src/main/java/com/yju/toonovel/domain/user/service/UserService.java
+++ b/src/main/java/com/yju/toonovel/domain/user/service/UserService.java
@@ -31,7 +31,7 @@ public class UserService {
 	}
 
 	@Transactional
-	public void register(Long id, UserRegisterRequestDto requestDto) {
+	public void updateUser(Long id, UserRegisterRequestDto requestDto) {
 		User user = userRepository.findByUserId(id)
 			.orElseThrow(() -> new UserNotFoundException());
 		user.register(requestDto.getNickname(), requestDto.getGender(), requestDto.getBirth());


### PR DESCRIPTION
### 📌 개발 개요
- resolve #55 
- User 도메인에 한해서 validation 작성
- 회원 탈퇴 - Soft Delete 로 변경
  <br>

### 💻  작업 및 변경 사항
- 회원 가입 요청에 사용되는 API가 회원 정보 수정과 현재 같다고 생각되어 메소드 이름을 변경하고, API 주소를 변경하였습니다.
  - `/register` -> `/me`
  - 메소드 이름을 `updateUser`로 일괄 변경
    - 기존에는 `regiser`,`userRegister` 가 혼용
- `UserRegisterRequestDto` 에 validation 작업
- 회원 탈퇴 정책 수정
  - 과거 구현한 회원 탈퇴 기능은 작동하지 않아 수정이 필요했습니다.
  -  Soft Delete로 변경하였습니다.
  <br>

### ✅ Point
- 코드나 정책 관련해서 의견 있으시면 말씀해주세요!!      
- 이미지 업로드 기능 추가 이후에, 회원 정보 수정 기능이 다시 분리되거나 변경될 가능성이 있습니다.                   
  <br>