### PR TITLE
[SETTING] 운영 환경과 개발 환경 설정 분리

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           files: ${{ env.RESOURCE_PATH }}
         env:
+          spring.profiles.active : ${{ secrets.ACTIVE_PROFILE }}
           spring.datasource.url: ${{ secrets.DB_URL }}
           spring.datasource.username: ${{ secrets.DB_USERNAME }}
           spring.datasource.password: ${{ secrets.DB_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -192,6 +192,14 @@
 
 ## 프로젝트 구조도
 
+### 서비스 아키텍처
+
+![test drawio (1)](https://github.com/TooNovel/TooNovel-BE/assets/83005178/7fad38c2-5c2b-4e73-94ba-d46519945347)
+
+### CI/CD
+
+![deploy drawio (1)](https://github.com/TooNovel/TooNovel-BE/assets/83005178/0c4d755c-d148-43a1-9fa9-5ba20be4e1eb)
+
 ## ERD
 
 ## API

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,4 +1,7 @@
 spring:
+  profiles:
+    active: ${ACTIVE_PROFILE}
+
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,24 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+    <conversionRule conversionWord="color" converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%-5p %d{yyyyMMdd HH:mm:ss.SSS} [%t] %c{3}, %M at line %L; %m%n</pattern>
+            <pattern>%color(%d{yyyy-MM-dd HH:mm:ss.SSS}){green} %color([%thread]){faint} %color(%-5level){} %color([%logger{0} : %line]){cyan} - %msg %n</pattern>
         </encoder>
     </appender>
 
-    <appender name="sentry" class="io.sentry.logback.SentryAppender">
+    <appender name="Sentry" class="io.sentry.logback.SentryAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>WARN</level>
+            <level>ERROR</level>
         </filter>
+        <encoder>
+            <pattern>%d{yyyyMMdd HH:mm:ss.SSS} [%thread] %-5level [%logger{0} : %line] - %msg %n</pattern>
+        </encoder>
     </appender>
 
-    <root level="info">
-        <appender-ref ref="console"/>
-        <appender-ref ref="sentry"/>
-    </root>
+    <springProfile name="develop">
+        <root level="INFO">
+            <appender-ref ref="Console" />
+        </root>
+    </springProfile>
 
-    <root level="debug">
-        <appender-ref ref="console"/>
-        <appender-ref ref="sentry"/>
-    </root>
+    <springProfile name="production">
+        <root level="INFO">
+            <appender-ref ref="Console" />
+            <appender-ref ref="Sentry" />
+        </root>
+    </springProfile>
 </configuration>


### PR DESCRIPTION
### 📌 개발 개요
- resolve #82 
- 이전에 작성한 #81 을 보충합니다.
  <br>

### 💻  작업 및 변경 사항
- `profile` 을 분리하였습니다.
  - 이제 개발환경에서는 `develop` 프로파일을 적용해주세요.
- 스프링부트 기본 로그와 비슷한 형태로 로그 출력형태를 수정하고, 색깔을 추가했습니다.
- 운영 환경에서만 `Sentry` 의 `appender` 를 적용하도록 하였습니다.
- 리드미에 서비스 아키텍처를 첨부하였습니다.
  <br>

### ✅ Point
- 로컬에서 환경변수 `ACTIVE_PROFILE` 을 `develop` 로 적용해주세요!                       
  <br>