### PR TITLE
[FEAT] S3 이미지 업로드 기능 구현

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,14 +42,10 @@ jobs:
           server.backEnd: ${{ secrets.BACKEND_URL }}
           server.machineLearning: ${{ secrets.ML_URL }}
           sentry.dsn: ${{ secrets.SENTRY_DSN }}
+          cloud.aws.s3.bucket: ${{ secrets.AWS_IMAGE_BUCKET }}
+          cloud.aws.credentials.access-key: ${{ AWS_IMAGE_BUCKET_ACCESS_KEY_ID }}
+          cloud.aws.credentials.secret-key: ${{ AWS_IMAGE_BUCKET_SECRET_KEY_ID }}
 
-      - name: Setup MySQL
-        uses: samin/mysql-action@v1
-        with:
-          character set server: 'utf8'
-          mysql database: 'toonovel'
-          mysql user: ${{ secrets.DB_USERNAME }}
-          mysql password: ${{ secrets.DB_PASSWORD }}
 
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew

--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,8 @@ dependencies {
     // QueryDSL
     implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
     implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
+    //AWS
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
     //API Docs
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.15'
     implementation 'org.springdoc:springdoc-openapi-security:1.6.15'

--- a/src/main/java/com/yju/toonovel/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/yju/toonovel/domain/comment/controller/CommentController.java
@@ -37,7 +37,7 @@ public class CommentController {
 	private final LikeCommentService likeCommentService;
 
 	@Operation(summary = "댓글 작성")
-	@ApiResponse(responseCode = "200", description = "요청 성공")
+	@ApiResponse(responseCode = "201", description = "요청 성공")
 	@ApiResponse(responseCode = "404", description = "유저나 게시글이 없는 상태일 때")
 	@PostMapping()
 	@ResponseStatus(HttpStatus.CREATED)

--- a/src/main/java/com/yju/toonovel/global/aws/controller/AwsController.java
+++ b/src/main/java/com/yju/toonovel/global/aws/controller/AwsController.java
@@ -1,0 +1,35 @@
+package com.yju.toonovel.global.aws.controller;
+
+import java.io.Serializable;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.yju.toonovel.global.aws.service.S3Service;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/aws")
+@RequiredArgsConstructor
+public class AwsController {
+
+	private final S3Service s3Service;
+
+	@GetMapping
+	@ResponseStatus(HttpStatus.OK)
+	public void getHealthCheck() {
+	}
+
+	@GetMapping("/s3")
+	@ResponseStatus(HttpStatus.OK)
+	public Map<String, Serializable> getPreSignedUrl(@RequestParam String fileName) {
+		return s3Service.getPreSignedUrl(fileName);
+	}
+
+}

--- a/src/main/java/com/yju/toonovel/global/aws/service/S3Service.java
+++ b/src/main/java/com/yju/toonovel/global/aws/service/S3Service.java
@@ -1,0 +1,46 @@
+package com.yju.toonovel.global.aws.service;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.yju.toonovel.global.config.AwsConfig;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+	private final AwsConfig awsConfig;
+
+	@Value("${cloud.aws.s3.bucket}")
+	private String bucket;
+
+	public Map<String, Serializable> getPreSignedUrl(String fileName) {
+		String encodedFileName = LocalDateTime.now() + "_" + fileName;
+		String objectKey = "image/" + encodedFileName;
+
+		Date expiration = new Date();
+		long expTimeMillis = expiration.getTime();
+		expTimeMillis += (2 * 60 * 1000);
+		expiration.setTime(expTimeMillis);
+
+		GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(bucket, objectKey)
+			.withMethod(HttpMethod.PUT)
+			.withExpiration(expiration);
+
+		Map<String, Serializable> result = new HashMap<>();
+		result.put("preSignedUrl", awsConfig.amazonS3().generatePresignedUrl(generatePresignedUrlRequest));
+		result.put("encodedFileName", encodedFileName);
+
+		return result;
+	}
+}

--- a/src/main/java/com/yju/toonovel/global/config/AwsConfig.java
+++ b/src/main/java/com/yju/toonovel/global/config/AwsConfig.java
@@ -1,0 +1,32 @@
+package com.yju.toonovel.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+@Configuration
+public class AwsConfig {
+	@Value("${cloud.aws.credentials.access-key}")
+	private String accessKey;
+
+	@Value("${cloud.aws.credentials.secret-key}")
+	private String secretKey;
+
+	@Value("${cloud.aws.region.static}")
+	private String region;
+
+	@Bean
+	public AmazonS3 amazonS3() {
+		AWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+		return AmazonS3ClientBuilder.standard()
+			.withRegion(region)
+			.withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+			.build();
+	}
+}

--- a/src/main/java/com/yju/toonovel/global/config/SecurityConfig.java
+++ b/src/main/java/com/yju/toonovel/global/config/SecurityConfig.java
@@ -45,6 +45,7 @@ public class SecurityConfig {
 			.antMatchers("/").permitAll()
 			.antMatchers("/token", "/api/**", "/login/**", "/oauth2/**").permitAll()
 			.antMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html", "/swagger-resources/**").permitAll()
+			.antMatchers("/api/v1/aws/s3").hasRole("USER")
 			.anyRequest().authenticated()
 			.and()
 			.httpBasic().disable()

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -74,3 +74,15 @@ sentry:
     minimum-breadcrumb-level: info
 
 
+cloud:
+  aws:
+    s3:
+      bucket: ${AWS_IMAGE_BUCKET}
+    credentials:
+      access-key: ${AWS_IMAGE_BUCKET_ACCESS_KEY_ID}
+      secret-key: ${AWS_IMAGE_BUCKET_SECRET_KEY_ID}
+    region:
+      static: ap-northeast-2
+      auto: false
+    stack:
+      auto: false


### PR DESCRIPTION
### 📌 개발 개요
- resolve #52 
- PreSignedUrl을 발급하는 방식으로 구현하였습니다.
- ElasticLoadBalancer에서 사용할 헬스 체크 엔드포인트를 추가하였습니다.
  <br>

### 💻  작업 및 변경 사항
- `MultipartFile`로 파일을 직접 받아 업로드하는 방식이 아니라, 백엔드에서는 `PreSignedUrl`만 발급해주고, 프론트에서 실제 파일을 업로드하는 방식으로 구현하였습니다.
  - 현재 해당 API는 Security에서 임시로 USER만 가능하도록 권한 설정하였으나 추후에 API들 권한 설정할 때 자세하게 설정하도록 하겠습니다.
- `ELB` 에서 헬스 체크 하는 API 엔드포인트를 만들었습니다.
  - 이전에는 `api/v1/novel` 로 체크하고 있었는데.. 의미 없는 트랜잭션이 발생하는 것 같았습니다.
  - 단순히 정상 작동 시 `200` 코드를 반환해줄 수 있는 엔드포인트입니다.
  <br>

### ✅ Point
- [AWS - PreSignedUrl](https://docs.aws.amazon.com/ko_kr/AmazonS3/latest/userguide/PresignedUrlUploadObject.html)
- [참고한 블로그 - AWS Presigned URL](https://velog.io/@hwaya2828/AWS-Presigned-URL)
- 궁금한 부분 있으시면 코멘트 주세요!                  
  <br>