### PR TITLE
[REFACTOR] 리프레쉬 토큰 로직 수정

### DIFF
--- a/src/main/java/com/yju/toonovel/global/security/jwt/controller/TokenController.java
+++ b/src/main/java/com/yju/toonovel/global/security/jwt/controller/TokenController.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.yju.toonovel.global.security.jwt.dto.TokenReIssueResponseDto;
 import com.yju.toonovel.global.security.jwt.service.TokenService;
+import com.yju.toonovel.global.util.CookieUtils;
 
 import lombok.RequiredArgsConstructor;
 
@@ -31,6 +33,19 @@ public class TokenController {
 
 		headers.add("Set-Cookie", tokenResponse.getAccessToken());
 		headers.add("Set-Cookie", tokenResponse.getRefreshToken());
+
+		return ResponseEntity.ok()
+			.headers(headers)
+			.build();
+	}
+
+	@DeleteMapping()
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public ResponseEntity<Void> deleteRefreshToken(@CookieValue("refreshTokenCookie") String refreshToken) {
+
+		tokenService.deleteRefreshToken(refreshToken);
+		HttpHeaders headers = new HttpHeaders();
+		headers.add("Set-Cookie", CookieUtils.getEmptyCookie("refreshTokenCookie"));
 
 		return ResponseEntity.ok()
 			.headers(headers)

--- a/src/main/java/com/yju/toonovel/global/security/jwt/controller/TokenController.java
+++ b/src/main/java/com/yju/toonovel/global/security/jwt/controller/TokenController.java
@@ -3,8 +3,8 @@ package com.yju.toonovel.global.security.jwt.controller;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,14 +21,12 @@ public class TokenController {
 
 	private final TokenService tokenService;
 
-	@PostMapping(value = "", headers = "Authorization-refresh")
+	@PostMapping()
 	@ResponseStatus(HttpStatus.CREATED)
-	public ResponseEntity<Void> reIssueTokens(
-		@RequestHeader("Authorization-refresh") String refreshToken) {
+	public ResponseEntity<Void> reIssueTokens(@CookieValue("refreshTokenCookie") String refreshToken) {
 
 		TokenReIssueResponseDto tokenResponse = tokenService.reIssueTokens(refreshToken);
 
-		// 헤더에 액세스 토큰과 리프레쉬 토큰 값을 설정
 		HttpHeaders headers = new HttpHeaders();
 
 		headers.add("Set-Cookie", tokenResponse.getAccessToken());

--- a/src/main/java/com/yju/toonovel/global/security/jwt/service/TokenService.java
+++ b/src/main/java/com/yju/toonovel/global/security/jwt/service/TokenService.java
@@ -100,4 +100,11 @@ public class TokenService {
 		return new JwtAuthenticationToken(principal, null, authorities);
 	}
 
+	@Transactional
+	public void deleteRefreshToken(String refreshToken) {
+
+		refreshTokenRepository.findByRefreshToken(refreshToken)
+			.ifPresent(token -> refreshTokenRepository.delete(token));
+	}
+
 }

--- a/src/main/java/com/yju/toonovel/global/security/jwt/service/TokenService.java
+++ b/src/main/java/com/yju/toonovel/global/security/jwt/service/TokenService.java
@@ -72,11 +72,11 @@ public class TokenService {
 	}
 
 	private String createAccessTokenCookie(String accessToken) {
-		return CookieUtils.addCookie("accessTokenCookie", accessToken, accessTokenExpireSeconds);
+		return CookieUtils.addAccessTokenCookie("accessTokenCookie", accessToken, accessTokenExpireSeconds);
 	}
 
 	private String createRefreshTokenCookie(String refreshToken) {
-		return CookieUtils.addCookie("refreshTokenCookie", refreshToken, refreshTokenExpireSeconds);
+		return CookieUtils.addRefreshTokenCookie("refreshTokenCookie", refreshToken, refreshTokenExpireSeconds);
 	}
 
 	public Optional<String> getAccessToken(HttpServletRequest request) {

--- a/src/main/java/com/yju/toonovel/global/security/oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/yju/toonovel/global/security/oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -74,6 +74,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 		ResponseCookie token = ResponseCookie.from("refreshTokenCookie", refreshToken)
 			.path(getDefaultTargetUrl())
 			.sameSite("None")
+			.httpOnly(true)
 			.secure(true)
 			.maxAge(refreshTokenExpireSeconds)
 			.build();

--- a/src/main/java/com/yju/toonovel/global/util/CookieUtils.java
+++ b/src/main/java/com/yju/toonovel/global/util/CookieUtils.java
@@ -54,6 +54,17 @@ public class CookieUtils {
 		return cookie.toString();
 	}
 
+	public static String getEmptyCookie(String name) {
+		ResponseCookie cookie = ResponseCookie.from(name, "")
+			.sameSite("None")
+			.path("/")
+			.httpOnly(true)
+			.secure(true)
+			.maxAge(0)
+			.build();
+		return cookie.toString();
+	}
+
 	public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
 		Cookie[] cookies = request.getCookies();
 		if (cookies != null) {

--- a/src/main/java/com/yju/toonovel/global/util/CookieUtils.java
+++ b/src/main/java/com/yju/toonovel/global/util/CookieUtils.java
@@ -33,9 +33,21 @@ public class CookieUtils {
 		response.addCookie(cookie);
 	}
 
-	public static String addCookie(String name, String value, int maxAge) {
+	public static String addAccessTokenCookie(String name, String value, int maxAge) {
 		ResponseCookie cookie = ResponseCookie.from(name, value)
 			.sameSite("None")
+			.path("/")
+			.secure(true)
+			.maxAge(maxAge)
+			.build();
+		return cookie.toString();
+	}
+
+	public static String addRefreshTokenCookie(String name, String value, int maxAge) {
+		ResponseCookie cookie = ResponseCookie.from(name, value)
+			.sameSite("None")
+			.path("/")
+			.httpOnly(true)
 			.secure(true)
 			.maxAge(maxAge)
 			.build();


### PR DESCRIPTION
### 📌 개발 개요
- resolve #97 
- 리프레쉬 토큰 정책 수정
  <br>

### 💻  작업 및 변경 사항
- `api/v1/token`  post 요청이 들어오는 재발급 요청에 대해서 쿠키의 값을 추출합니다.
  - FE에서 리프레쉬 토큰을 추출하여 헤더에 담을 필요 없이 그냥 요청하시면 됩니다.
- 토큰 발급 시 httpOnly 옵션을 설정하였습니다.
- `api/v1/token` delete 요청으로 로그아웃 API 를 추가하였습니다.
  - `httpOnly` 옵션의 쿠키를 빈 쿠키를 발급하여 덮어 씌웁니다.
  - 액세스 토큰은 별도로 처리하지 않았습니다. 필요 시 프론트에서 지워주시면 될 것 같습니다.
  <br>

### ✅ Point
- 이전에 이해도가 모자라서 빈틈이 많았던 로직입니다.
  - 액세스 토큰도 이후에는 굳이 쿠키에 담아서 전송하지 않고, 쿼리 스트링이나 바디에 담아주는 식으로 변경할 수 있을 것 같습니다.
    - 현재는 변동없이 쿠키에 담아서 전송하고 있습니다.
  - 리프레쉬 토큰은 `httpOnly` 쿠키로 발급합니다.
  <br>