### PR TITLE
[FEAT] 간단한 기능 추가 (정보 수정, 조회 기준 추가 등)

### DIFF
--- a/src/main/java/com/yju/toonovel/domain/novel/dto/NovelDetailResponseDto.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/dto/NovelDetailResponseDto.java
@@ -27,6 +27,8 @@ public class NovelDetailResponseDto {
 	private Genre genre;
 	@Schema(description = "좋아요 수")
 	private long likeCount;
+	@Schema(description = "리뷰 수")
+	private long reviewCount;
 	@Schema(description = "소설 평점")
 	private Double grade;
 	@Schema(description = "서비스 중인 플랫폼 리스트")
@@ -41,6 +43,7 @@ public class NovelDetailResponseDto {
 		this.author = novel.getAuthor();
 		this.genre = novel.getGenre();
 		this.likeCount = novel.getLikeCount();
+		this.reviewCount = novel.getReviewCount();
 		this.grade = novel.getGrade();
 		this.platforms = platform;
 		this.image = novel.getImage();

--- a/src/main/java/com/yju/toonovel/domain/novel/dto/NovelPaginationResponseDto.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/dto/NovelPaginationResponseDto.java
@@ -21,17 +21,23 @@ public class NovelPaginationResponseDto {
 	private Genre genre;
 	@Schema(description = "소설 평점")
 	private Double grade;
+	@Schema(description = "리뷰 수")
+	private Long reviewCount;
+	@Schema(description = "좋아요 수")
+	private Long likeCount;
 	@Schema(description = "소설 표지")
 	private String image;
 
 	@Builder
 	public NovelPaginationResponseDto(Long novelId, String title, String author, Genre genre, Double grade,
-		String image) {
+		Long reviewCount, Long likeCount, String image) {
 		this.novelId = novelId;
 		this.title = title;
 		this.author = author;
 		this.genre = genre;
 		this.grade = grade;
+		this.reviewCount = reviewCount;
+		this.likeCount = likeCount;
 		this.image = image;
 	}
 
@@ -42,6 +48,8 @@ public class NovelPaginationResponseDto {
 			novel.getAuthor(),
 			novel.getGenre(),
 			novel.getGrade(),
+			novel.getReviewCount(),
+			novel.getLikeCount(),
 			novel.getImage()
 		);
 	}

--- a/src/main/java/com/yju/toonovel/domain/novel/entity/Novel.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/entity/Novel.java
@@ -54,6 +54,10 @@ public class Novel extends BaseEntity {
 	@Formula("(SELECT FORMAT(AVG(r.review_grade), 1) FROM review r WHERE r.novel_id = novel_id)")
 	private Double grade;
 
+	@Basic(fetch = FetchType.LAZY)
+	@Formula("(SELECT COUNT(1) FROM review r WHERE r.novel_id = novel_id)")
+	private long reviewCount;
+
 	@OneToMany(mappedBy = "novel")
 	private List<NovelPlatform> novelPlatforms = new ArrayList<>();
 

--- a/src/main/java/com/yju/toonovel/domain/post/dto/PostAllResponseDto.java
+++ b/src/main/java/com/yju/toonovel/domain/post/dto/PostAllResponseDto.java
@@ -27,11 +27,13 @@ public class PostAllResponseDto {
 	private Long viewCount;
 	@Schema(description = "유저 닉네임")
 	private String nickname;
+	@Schema(description = "댓글 수")
+	private long commentCount;
 
 	@Builder
 	public PostAllResponseDto(Long postId, Category category,
 		String title, LocalDateTime createdDate,
-		Long viewCount, String nickname) {
+		Long viewCount, String nickname, long commentCount) {
 
 		this.postId = postId;
 		this.category = category;
@@ -39,6 +41,7 @@ public class PostAllResponseDto {
 		this.createdDate = createdDate;
 		this.viewCount = viewCount;
 		this.nickname = nickname;
+		this.commentCount = commentCount;
 	}
 
 	public PostAllResponseDto(Post post) {
@@ -49,6 +52,7 @@ public class PostAllResponseDto {
 		this.createdDate = post.getCreatedDate();
 		this.viewCount = post.getViewCount();
 		this.nickname = post.getUser().getNickname();
+		this.commentCount = post.getCommentCount();
 	}
 
 }

--- a/src/main/java/com/yju/toonovel/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/com/yju/toonovel/domain/post/dto/PostResponseDto.java
@@ -31,6 +31,8 @@ public class PostResponseDto {
 	private Long viewCount;
 	@Schema(description = "유저 닉네임")
 	private String nickname;
+	@Schema(description = "댓글 수")
+	private long commentCount;
 
 	public PostResponseDto(Post post) {
 		this.postId = post.getPostId();
@@ -42,5 +44,6 @@ public class PostResponseDto {
 		this.like = post.getLike();
 		this.viewCount = post.getViewCount();
 		this.nickname = post.getUser().getNickname();
+		this.commentCount = post.getCommentCount();
 	}
 }

--- a/src/main/java/com/yju/toonovel/domain/post/entity/Post.java
+++ b/src/main/java/com/yju/toonovel/domain/post/entity/Post.java
@@ -1,5 +1,6 @@
 package com.yju.toonovel.domain.post.entity;
 
+import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -14,6 +15,7 @@ import javax.persistence.ManyToOne;
 
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.Formula;
 
 import com.yju.toonovel.domain.user.entity.User;
 import com.yju.toonovel.global.common.entity.BaseEntity;
@@ -55,6 +57,10 @@ public class Post extends BaseEntity {
 	@Column(name = "view_count")
 	@ColumnDefault("0")
 	private Long viewCount;
+
+	@Basic(fetch = FetchType.LAZY)
+	@Formula("(SELECT COUNT(1) FROM comment c WHERE c.post_id = post_id)")
+	private long commentCount;
 
 	@Builder
 	public Post(User user, Category category, String title, String content) {

--- a/src/main/java/com/yju/toonovel/domain/post/service/PostService.java
+++ b/src/main/java/com/yju/toonovel/domain/post/service/PostService.java
@@ -49,6 +49,7 @@ public class PostService {
 	}
 
 	// 게시글 전체 조회
+	@Transactional
 	public Page<PostAllResponseDto> getAllPost(PostPaginationRequestDto requestDto) {
 		Pageable pageable = PageRequest.of(requestDto.getPage(), requestDto.getLimit());
 		return postRepositoryImpl.getAllPost(pageable, requestDto);

--- a/src/main/java/com/yju/toonovel/domain/user/controller/UserController.java
+++ b/src/main/java/com/yju/toonovel/domain/user/controller/UserController.java
@@ -19,7 +19,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.yju.toonovel.domain.novel.dto.LikeNovelPaginationResponseDto;
 import com.yju.toonovel.domain.user.dto.AuthorRegisterRequestDto;
+import com.yju.toonovel.domain.user.dto.UserMyProfileResponseDto;
 import com.yju.toonovel.domain.user.dto.UserProfileResponseDto;
+import com.yju.toonovel.domain.user.dto.UserProfileUpdateRequestDto;
 import com.yju.toonovel.domain.user.dto.UserRegisterRequestDto;
 import com.yju.toonovel.domain.user.service.UserService;
 import com.yju.toonovel.global.security.jwt.JwtAuthentication;
@@ -50,8 +52,18 @@ public class UserController {
 	@ApiResponse(responseCode = "404", description = "해당 유저가 없는 상태일 때")
 	@GetMapping("/me")
 	@ResponseStatus(HttpStatus.OK)
-	public UserProfileResponseDto getMyProfile(@AuthenticationPrincipal JwtAuthentication user) {
-		return userService.getUserProfile(user.userId);
+	public UserMyProfileResponseDto getMyProfile(@AuthenticationPrincipal JwtAuthentication user) {
+		return userService.getMyProfile(user.userId);
+	}
+
+	@Operation(summary = "유저 기본 정보 입력 요청")
+	@ApiResponse(responseCode = "201", description = "요청 성공")
+	@ApiResponse(responseCode = "404", description = "해당 유저가 없는 상태일 때")
+	@PatchMapping("/join")
+	@ResponseStatus(HttpStatus.CREATED)
+	public void registerUser(@RequestBody @Valid UserRegisterRequestDto requestDto,
+		@AuthenticationPrincipal JwtAuthentication user) {
+		userService.registerUser(user.userId, requestDto);
 	}
 
 	@Operation(summary = "유저 탈퇴 요청")
@@ -63,14 +75,14 @@ public class UserController {
 		userService.deleteUser(user.userId);
 	}
 
-	@Operation(summary = "유저 정보 수정 요청")
+	@Operation(summary = "유저 프로필 수정 요청")
 	@ApiResponse(responseCode = "201", description = "요청 성공")
 	@ApiResponse(responseCode = "404", description = "해당 유저가 없는 상태일 때")
 	@PatchMapping("/me")
 	@ResponseStatus(HttpStatus.CREATED)
-	public void updateUser(@RequestBody @Valid UserRegisterRequestDto requestDto,
+	public void updateUserProfile(@RequestBody @Valid UserProfileUpdateRequestDto requestDto,
 		@AuthenticationPrincipal JwtAuthentication user) {
-		userService.updateUser(user.userId, requestDto);
+		userService.updateProfile(user.userId, requestDto);
 	}
 
 	@Operation(summary = "좋아요한 소설 조회 요청")

--- a/src/main/java/com/yju/toonovel/domain/user/dto/UserMyProfileResponseDto.java
+++ b/src/main/java/com/yju/toonovel/domain/user/dto/UserMyProfileResponseDto.java
@@ -1,0 +1,32 @@
+package com.yju.toonovel.domain.user.dto;
+
+import com.yju.toonovel.domain.user.entity.User;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Schema(description = "유저 마이 프로필 조회 응답 DTO")
+@Getter
+public class UserMyProfileResponseDto {
+
+	@Schema(description = "유저 ID")
+	private Long userId;
+	@Schema(description = "유저 닉네임")
+	private String nickname;
+	@Schema(description = "유저 프로필 사진")
+	private String imageUrl;
+	@Schema(description = "유저 성별")
+	private String gender;
+	@Schema(description = "유저 생년월일")
+	private String birth;
+
+	public UserMyProfileResponseDto(User user) {
+		this.userId = user.getUserId();
+		this.nickname = user.getNickname();
+		this.imageUrl = user.getImageUrl();
+		this.gender = user.getGender();
+		this.birth = user.getBirth();
+
+	}
+
+}

--- a/src/main/java/com/yju/toonovel/domain/user/dto/UserProfileUpdateRequestDto.java
+++ b/src/main/java/com/yju/toonovel/domain/user/dto/UserProfileUpdateRequestDto.java
@@ -1,0 +1,40 @@
+package com.yju.toonovel.domain.user.dto;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+import org.hibernate.validator.constraints.Length;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "회원 프로필 수정 요청 DTO")
+@Getter
+@NoArgsConstructor
+public class UserProfileUpdateRequestDto {
+
+	@Schema(description = "닉네임")
+	@Length(max = 15)
+	@NotBlank
+	private String nickname;
+	@Schema(description = "성별")
+	@NotBlank
+	private String gender;
+	@Schema(description = "유저 프로필 사진")
+	private String imageUrl;
+	@Schema(description = "생년월일")
+	@NotBlank
+	@Pattern(regexp = "(19|20)\\d{2}\\-(0[1-9]|1[012])\\-(0[1-9]|[12][0-9]|3[01])")
+	private String birth;
+
+	@Builder
+	public UserProfileUpdateRequestDto(String nickname, String gender, String imageUrl, String birth) {
+		this.nickname = nickname;
+		this.gender = gender;
+		this.imageUrl = imageUrl;
+		this.birth = birth;
+	}
+
+}

--- a/src/main/java/com/yju/toonovel/domain/user/entity/User.java
+++ b/src/main/java/com/yju/toonovel/domain/user/entity/User.java
@@ -66,11 +66,18 @@ public class User extends BaseEntity {
 		this.birth = birth;
 	}
 
-	public void update(String nickname, String gender, String birth) {
+	public void register(String nickname, String gender, String birth) {
 		this.nickname = nickname;
 		this.gender = gender;
 		this.birth = birth;
 		this.role = Role.USER;
+	}
+
+	public void updateProfile(String nickname, String imageUrl, String gender, String birth) {
+		this.nickname = nickname;
+		this.imageUrl = imageUrl;
+		this.gender = gender;
+		this.birth = birth;
 	}
 
 	public void updateRole(Role role) {

--- a/src/main/java/com/yju/toonovel/domain/user/service/UserService.java
+++ b/src/main/java/com/yju/toonovel/domain/user/service/UserService.java
@@ -102,7 +102,9 @@ public class UserService {
 				isAuthor -> {
 					enrollRepository.save(EnrollHistory.of(user));
 				},
-				() -> new AuthorNotFoundException()
+				() -> {
+					throw new AuthorNotFoundException();
+				}
 			);
 	}
 }

--- a/src/main/java/com/yju/toonovel/domain/user/service/UserService.java
+++ b/src/main/java/com/yju/toonovel/domain/user/service/UserService.java
@@ -13,7 +13,9 @@ import com.yju.toonovel.domain.novel.exception.AuthorNotFoundException;
 import com.yju.toonovel.domain.novel.repository.LikeNovelRepository;
 import com.yju.toonovel.domain.novel.repository.NovelRepository;
 import com.yju.toonovel.domain.user.dto.AuthorRegisterRequestDto;
+import com.yju.toonovel.domain.user.dto.UserMyProfileResponseDto;
 import com.yju.toonovel.domain.user.dto.UserProfileResponseDto;
+import com.yju.toonovel.domain.user.dto.UserProfileUpdateRequestDto;
 import com.yju.toonovel.domain.user.dto.UserRegisterRequestDto;
 import com.yju.toonovel.domain.user.entity.Role;
 import com.yju.toonovel.domain.user.entity.User;
@@ -33,6 +35,7 @@ public class UserService {
 	private final NovelRepository novelRepository;
 	private final EnrollRepository enrollRepository;
 
+	@Transactional
 	public UserProfileResponseDto getUserProfile(Long id) {
 		User user = userRepository.findById(id)
 			.orElseThrow(() -> new UserNotFoundException());
@@ -40,10 +43,25 @@ public class UserService {
 	}
 
 	@Transactional
-	public void updateUser(Long id, UserRegisterRequestDto requestDto) {
+	public UserMyProfileResponseDto getMyProfile(Long id) {
+		User user = userRepository.findById(id)
+			.orElseThrow(() -> new UserNotFoundException());
+		return new UserMyProfileResponseDto(user);
+	}
+
+	@Transactional
+	public void registerUser(Long id, UserRegisterRequestDto requestDto) {
 		User user = userRepository.findByUserId(id)
 			.orElseThrow(() -> new UserNotFoundException());
-		user.update(requestDto.getNickname(), requestDto.getGender(), requestDto.getBirth());
+		user.register(requestDto.getNickname(), requestDto.getGender(), requestDto.getBirth());
+	}
+
+	@Transactional
+	public void updateProfile(Long id, UserProfileUpdateRequestDto requestDto) {
+		User user = userRepository.findByUserId(id)
+			.orElseThrow(() -> new UserNotFoundException());
+		user.updateProfile(requestDto.getNickname(), requestDto.getGender(), requestDto.getImageUrl(),
+			requestDto.getBirth());
 	}
 
 	@Transactional

--- a/src/main/java/com/yju/toonovel/global/common/Sort.java
+++ b/src/main/java/com/yju/toonovel/global/common/Sort.java
@@ -6,7 +6,9 @@ public enum Sort {
 	CREATED_DATE_DESC("createdDate", Order.DESC),
 	CREATED_DATE_ASC("createdDate", Order.ASC),
 	REVIEW_LIKE_DESC("reviewLike", Order.DESC),
-	NOVEL_GRADE_DESC("grade", Order.DESC);
+	NOVEL_GRADE_DESC("grade", Order.DESC),
+	NOVEL_REVIEW_DESC("reviewCount", Order.DESC),
+	NOVEL_LIKE_DESC("likeCount", Order.DESC);
 
 	private final String property;
 	private final Order order;


### PR DESCRIPTION
### 📌 개발 개요
- resolve #95 
- 요구 사항 변경에 따른 간단한 추가 작업
  <br>

### 💻  작업 및 변경 사항
- `User`
  - 유저 정보 업데이트 API 분리 및 추가
    - 이전에 회원가입 -> 추가정보 입력에서 사용되는 API의 경로가 `api/v1/user/join`으로 변경되었습니다.
    - 마이페이지 - 프로필 수정에서 사용되는 API를 추가하고, 경로를 `api/v1/user/me`로 하였습니다.
  - 유저 정보 반환 Dto 분리
    - 내 프로필 조회와 타인 프로필 조회 시 반환되는 Dto를 분리하였습니다.
  - `AuthorNotFoundException` 이 던져지지 않는 것을 발견하여 수정하였습니다.
- `Novel`
  - 좋아요 수, 리뷰 수 순으로 조회하는 기능을 추가하였습니다.
  - 전체, 상세 조회 시 리뷰 수, 좋아요 수도 반환하도록 하였습니다.
- `Post` 
  - 누락 작품 신청 카테고리 : 이미 존재하는 건의가 그 역할을 할 수 있을 것 같아서 그대로 두었습니다.
  - 전체, 상세 조회 시 댓글 수를 반환하도록 하였습니다.
  <br>

### ✅ Point
- 전체적으로 리팩터링이 필요하다고 느꼈습니다. 다만 당장에 수정하지는 않았습니다.
  - 초기에 작성한 코드와 이후에 작성한 코드가 스타일이 많이 다른 것을 인지했습니다.
  - 정적 팩토리 메소드나 빌더 패턴 등을 사용하여 좀 더 깔끔하게 작성 가능한 부분이 많이 보였습니다.
  - 이후에 기간을 충분히 잡고 함께 고쳐보는게 좋을 것 같습니다.
- **수정할 부분이나,  더 추가할 부분 있으면 말씀해주시면 빠르게 반영하겠습니다!**
  <br>