### PR TITLE
[FEAT] 메시지 클린봇(필터링) 기능 추가

### DIFF
--- a/src/main/java/com/yju/toonovel/domain/chatting/dto/ChatDto.java
+++ b/src/main/java/com/yju/toonovel/domain/chatting/dto/ChatDto.java
@@ -30,6 +30,9 @@ public class ChatDto {
 	@Schema(description = "채팅 내용")
 	private String message;
 
+	@Schema(description = "메시지 필터링 결과 'ok' or 'bad'")
+	private String filterResult;
+
 	@Builder
 	public ChatDto(Long chatId, String senderName, Long senderId, boolean isCreator, String message) {
 		this.chatId = chatId;

--- a/src/main/java/com/yju/toonovel/domain/chatting/dto/FilterChatRequestDto.java
+++ b/src/main/java/com/yju/toonovel/domain/chatting/dto/FilterChatRequestDto.java
@@ -1,0 +1,17 @@
+package com.yju.toonovel.domain.chatting.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FilterChatRequestDto {
+
+	private String message;
+
+	@Builder
+	public FilterChatRequestDto(String message) {
+		this.message = message;
+	}
+}

--- a/src/main/java/com/yju/toonovel/domain/chatting/dto/FilterChatResponseDto.java
+++ b/src/main/java/com/yju/toonovel/domain/chatting/dto/FilterChatResponseDto.java
@@ -1,0 +1,17 @@
+package com.yju.toonovel.domain.chatting.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FilterChatResponseDto {
+
+	private String filteredResult;
+
+	@Builder
+	public FilterChatResponseDto(String filteredResult) {
+		this.filteredResult = filteredResult;
+	}
+}

--- a/src/main/java/com/yju/toonovel/domain/chatting/entity/Chat.java
+++ b/src/main/java/com/yju/toonovel/domain/chatting/entity/Chat.java
@@ -25,7 +25,7 @@ public class Chat extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long chatId;
 
-	@Column(nullable = false)
+	@Column(nullable = false, length = 300)
 	private String message;
 
 	@ManyToOne(fetch = FetchType.LAZY)
@@ -36,18 +36,26 @@ public class Chat extends BaseEntity {
 	@JoinColumn(name = "sender_id")
 	private User user;
 
+	private boolean isFiltered;
+
 	@Builder
-	public Chat(String message, ChatRoom chatRoom, User user) {
+	public Chat(String message, ChatRoom chatRoom, User user, boolean isFiltered) {
 		this.message = message;
 		this.chatRoom = chatRoom;
 		this.user = user;
+		this.isFiltered = isFiltered;
 	}
 
-	public static Chat of(String message, ChatRoom chatRoom, User user) {
+	public static Chat of(String message, ChatRoom chatRoom, User user, boolean isFiltered) {
 		return Chat.builder()
 			.message(message)
 			.chatRoom(chatRoom)
 			.user(user)
+			.isFiltered(isFiltered)
 			.build();
+	}
+
+	public void filteringChat() {
+		isFiltered = !isFiltered;
 	}
 }


### PR DESCRIPTION
### 📌 개발 개요
- resolve #104 
- 메신져 기능에서 사용자가 작가에게 메시지를 보낼 때, 악의적인 메시지가 전송이 되었을 때 필터링이 될 수 있도록 학습된 모델을 통하여 메시지 필터링 기능 구현
  <br>

### 💻  작업 및 변경 사항
- `Chat` 엔티티
  - `isFiltered` 컬럼 추가하여 필터링 되었는지 안되었는지 판단
  - ChatDto의 메시지 length와 Chat엔티티의 메시지 length를 동일하게 맞추었습니다.
- `ChatService`
  - filterChat 메서드 추가
    - json 데이터를 보내기 위해서 restTmplate의 postForEntity메서드 사용
    - 필터링 요청, 응답 각각의 데이터 전달을 위해 dto 생성
  <br>

### ✅ Point
- `Chat` 엔티티에 `isFiltered`변수를 사용하였고, front에 전달되는 `ChatDto` 에는 `filterResult` 변수를 사용하였습니다. 혹여나 변수 네이밍 더 좋을 것 같은게 있으시면 말씀부탁드립니다.
- restTmplate 으로 JSON 데이터를 보내는 문법에 관해서는 https://velog.io/@seongwon97/Spring-Boot-Rest-Template#ex-postforentity 블로그를 참고하였습니다.
  <br>