### PR TITLE
[FEAT] API 기능 보충 (최신작가, 인기리뷰, 인기채팅룸)

### DIFF
--- a/src/main/java/com/yju/toonovel/domain/chatting/controller/ChatRoomHttpController.java
+++ b/src/main/java/com/yju/toonovel/domain/chatting/controller/ChatRoomHttpController.java
@@ -79,7 +79,7 @@ public class ChatRoomHttpController {
 		chatRoomService.leaveChatRoom(rid, user.userId);
 	}
 
-	@Operation(summary = "채팅방 리스트 조회")
+	@Operation(summary = "자신이 가입한 채팅방 리스트 조회")
 	@ApiResponse(responseCode = "200", description = "요청 성공")
 	@GetMapping()
 	@ResponseStatus(HttpStatus.OK)

--- a/src/main/java/com/yju/toonovel/domain/user/controller/UserController.java
+++ b/src/main/java/com/yju/toonovel/domain/user/controller/UserController.java
@@ -111,8 +111,8 @@ public class UserController {
 	@ApiResponse(responseCode = "200", description = "요청 성공")
 	@GetMapping("/author")
 	@ResponseStatus(HttpStatus.OK)
-	public List<AuthorListResponseDto> getNewAuthor(@ModelAttribute AuthorListPaginationRequestDto dto) {
-		return userService.findNewAuthor(dto);
+	public List<AuthorListResponseDto> getAuthor(@ModelAttribute AuthorListPaginationRequestDto dto) {
+		return userService.findAuthor(dto);
 	}
 
 	@Operation(summary = "인기 채팅방 조회 요청")

--- a/src/main/java/com/yju/toonovel/domain/user/controller/UserController.java
+++ b/src/main/java/com/yju/toonovel/domain/user/controller/UserController.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,6 +19,8 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.yju.toonovel.domain.novel.dto.LikeNovelPaginationResponseDto;
+import com.yju.toonovel.domain.user.dto.AuthorListPaginationRequestDto;
+import com.yju.toonovel.domain.user.dto.AuthorListResponseDto;
 import com.yju.toonovel.domain.user.dto.AuthorRegisterRequestDto;
 import com.yju.toonovel.domain.user.dto.UserMyProfileResponseDto;
 import com.yju.toonovel.domain.user.dto.UserProfileResponseDto;
@@ -104,4 +107,12 @@ public class UserController {
 		userService.authorEnroll(user.userId, dto);
 	}
 
+	@Operation(summary = "최신 작가 요청")
+	@ApiResponse(responseCode = "200", description = "요청 성공")
+	@GetMapping("/author")
+	@ResponseStatus(HttpStatus.OK)
+	public List<AuthorListResponseDto> getNewAuthor(@ModelAttribute AuthorListPaginationRequestDto dto) {
+		return userService.findNewAuthor(dto);
+	}
 }
+

--- a/src/main/java/com/yju/toonovel/domain/user/controller/UserController.java
+++ b/src/main/java/com/yju/toonovel/domain/user/controller/UserController.java
@@ -107,7 +107,7 @@ public class UserController {
 		userService.authorEnroll(user.userId, dto);
 	}
 
-	@Operation(summary = "최신 작가 요청")
+	@Operation(summary = "작가 리스트 조회 요청")
 	@ApiResponse(responseCode = "200", description = "요청 성공")
 	@GetMapping("/author")
 	@ResponseStatus(HttpStatus.OK)

--- a/src/main/java/com/yju/toonovel/domain/user/controller/UserController.java
+++ b/src/main/java/com/yju/toonovel/domain/user/controller/UserController.java
@@ -114,5 +114,13 @@ public class UserController {
 	public List<AuthorListResponseDto> getNewAuthor(@ModelAttribute AuthorListPaginationRequestDto dto) {
 		return userService.findNewAuthor(dto);
 	}
+
+	@Operation(summary = "인기 채팅방 조회 요청")
+	@ApiResponse(responseCode = "200", description = "요청 성공")
+	@GetMapping("/chatroom")
+	@ResponseStatus(HttpStatus.OK)
+	public List<AuthorListResponseDto> getPopularChatRoomAuthor() {
+		return userService.findPopularChatRoomAuthor();
+	}
 }
 

--- a/src/main/java/com/yju/toonovel/domain/user/dto/AuthorListPaginationRequestDto.java
+++ b/src/main/java/com/yju/toonovel/domain/user/dto/AuthorListPaginationRequestDto.java
@@ -1,0 +1,24 @@
+package com.yju.toonovel.domain.user.dto;
+
+import com.yju.toonovel.global.common.Sort;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Schema(description = "작가 리스트 조회 요청 DTO")
+@Getter
+@Setter
+@NoArgsConstructor
+public class AuthorListPaginationRequestDto {
+
+	@Schema(description = "이전에 받은 마지막 enroll ID", defaultValue = "0")
+	private Long enrollId = 0L;
+
+	@Schema(description = "한 페이지 안에 담길 작가의 수", defaultValue = "30")
+	private Integer limit = 30;
+
+	@Schema(description = "정렬 기준", defaultValue = "CREATED_DATE_DESC")
+	private Sort sort = Sort.CREATED_DATE_DESC;
+}

--- a/src/main/java/com/yju/toonovel/domain/user/dto/AuthorListPaginationRequestDto.java
+++ b/src/main/java/com/yju/toonovel/domain/user/dto/AuthorListPaginationRequestDto.java
@@ -13,8 +13,8 @@ import lombok.Setter;
 @NoArgsConstructor
 public class AuthorListPaginationRequestDto {
 
-	@Schema(description = "이전에 받은 마지막 enroll ID", defaultValue = "0")
-	private Long enrollId = 0L;
+	@Schema(description = "이전에 받은 마지막 enroll ID")
+	private Long enrollId;
 
 	@Schema(description = "한 페이지 안에 담길 작가의 수", defaultValue = "30")
 	private Integer limit = 30;

--- a/src/main/java/com/yju/toonovel/domain/user/dto/AuthorListPaginationRequestDto.java
+++ b/src/main/java/com/yju/toonovel/domain/user/dto/AuthorListPaginationRequestDto.java
@@ -16,6 +16,9 @@ public class AuthorListPaginationRequestDto {
 	@Schema(description = "이전에 받은 마지막 enroll ID")
 	private Long enrollId;
 
+	@Schema(description = "작가 이름")
+	private String nickname;
+
 	@Schema(description = "한 페이지 안에 담길 작가의 수", defaultValue = "30")
 	private Integer limit = 30;
 

--- a/src/main/java/com/yju/toonovel/domain/user/dto/AuthorListResponseDto.java
+++ b/src/main/java/com/yju/toonovel/domain/user/dto/AuthorListResponseDto.java
@@ -1,0 +1,19 @@
+package com.yju.toonovel.domain.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "최신 작가 요청 DTO")
+@Getter
+@NoArgsConstructor
+public class AuthorListResponseDto {
+	@Schema(description = "작가 ID")
+	private Long userId;
+
+	@Schema(description = "작가의 닉네임")
+	private String nickname;
+
+	@Schema(description = "작가의 프로필 사진")
+	private String imageUrl;
+}

--- a/src/main/java/com/yju/toonovel/domain/user/dto/AuthorListResponseDto.java
+++ b/src/main/java/com/yju/toonovel/domain/user/dto/AuthorListResponseDto.java
@@ -1,12 +1,14 @@
 package com.yju.toonovel.domain.user.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Schema(description = "최신 작가 요청 DTO")
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class AuthorListResponseDto {
 	@Schema(description = "작가 ID")
 	private Long userId;

--- a/src/main/java/com/yju/toonovel/domain/user/repository/ChatRoomCustomRepository.java
+++ b/src/main/java/com/yju/toonovel/domain/user/repository/ChatRoomCustomRepository.java
@@ -1,0 +1,9 @@
+package com.yju.toonovel.domain.user.repository;
+
+import java.util.List;
+
+import com.yju.toonovel.domain.chatting.entity.ChatRoom;
+
+public interface ChatRoomCustomRepository {
+	List<ChatRoom> findByChatRoomMemberCount();
+}

--- a/src/main/java/com/yju/toonovel/domain/user/repository/ChatRoomCustomRepositoryImpl.java
+++ b/src/main/java/com/yju/toonovel/domain/user/repository/ChatRoomCustomRepositoryImpl.java
@@ -1,0 +1,30 @@
+package com.yju.toonovel.domain.user.repository;
+
+import static com.yju.toonovel.domain.chatting.entity.QChatRoom.*;
+import static com.yju.toonovel.domain.user.entity.QUser.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.yju.toonovel.domain.chatting.entity.ChatRoom;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ChatRoomCustomRepositoryImpl implements ChatRoomCustomRepository {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public List<ChatRoom> findByChatRoomMemberCount() {
+		return jpaQueryFactory
+			.selectFrom(chatRoom)
+			.join(chatRoom.user, user).fetchJoin() // n+1 방지
+			.orderBy(chatRoom.users.size().desc())
+			.limit(10)
+			.fetch();
+	}
+}

--- a/src/main/java/com/yju/toonovel/domain/user/repository/EnrollCustomRepository.java
+++ b/src/main/java/com/yju/toonovel/domain/user/repository/EnrollCustomRepository.java
@@ -2,9 +2,9 @@ package com.yju.toonovel.domain.user.repository;
 
 import java.util.List;
 
+import com.yju.toonovel.domain.user.dto.AuthorListPaginationRequestDto;
 import com.yju.toonovel.domain.user.dto.AuthorListResponseDto;
-import com.yju.toonovel.global.common.Sort;
 
 public interface EnrollCustomRepository {
-	List<AuthorListResponseDto> findAllAuthor(Long enrollId, Integer limit, Sort sort);
+	List<AuthorListResponseDto> findAllAuthor(AuthorListPaginationRequestDto dto);
 }

--- a/src/main/java/com/yju/toonovel/domain/user/repository/EnrollCustomRepository.java
+++ b/src/main/java/com/yju/toonovel/domain/user/repository/EnrollCustomRepository.java
@@ -1,0 +1,10 @@
+package com.yju.toonovel.domain.user.repository;
+
+import java.util.List;
+
+import com.yju.toonovel.domain.user.dto.AuthorListResponseDto;
+import com.yju.toonovel.global.common.Sort;
+
+public interface EnrollCustomRepository {
+	List<AuthorListResponseDto> findAllAuthor(Long enrollId, Integer limit, Sort sort);
+}

--- a/src/main/java/com/yju/toonovel/domain/user/repository/EnrollCustomRepositoryImpl.java
+++ b/src/main/java/com/yju/toonovel/domain/user/repository/EnrollCustomRepositoryImpl.java
@@ -50,7 +50,7 @@ public class EnrollCustomRepositoryImpl implements EnrollCustomRepository {
 	}
 
 	private Predicate makeWhereCondition(Long enrollId, Sort sort) {
-		if (sort == Sort.CREATED_DATE_DESC && enrollId.equals(0L)) {
+		if (enrollId == null) {
 			return null;
 		} else if (sort == Sort.CREATED_DATE_DESC) {
 			return enrollHistory.enrollId.lt(enrollId);

--- a/src/main/java/com/yju/toonovel/domain/user/repository/EnrollCustomRepositoryImpl.java
+++ b/src/main/java/com/yju/toonovel/domain/user/repository/EnrollCustomRepositoryImpl.java
@@ -1,0 +1,62 @@
+package com.yju.toonovel.domain.user.repository;
+
+import static com.yju.toonovel.domain.admin.entity.QEnrollHistory.*;
+import static com.yju.toonovel.domain.user.entity.QUser.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.yju.toonovel.domain.user.dto.AuthorListResponseDto;
+import com.yju.toonovel.global.common.Sort;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class EnrollCustomRepositoryImpl implements EnrollCustomRepository {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public List<AuthorListResponseDto> findAllAuthor(Long enrollId, Integer limit, Sort sort) {
+		return jpaQueryFactory
+			.select(Projections.fields(
+				AuthorListResponseDto.class,
+				enrollHistory.user.userId,
+				enrollHistory.user.nickname,
+				enrollHistory.user.imageUrl
+			))
+			.from(enrollHistory)
+			.join(enrollHistory.user, user)
+			.where(makeWhereCondition(enrollId, sort))
+			.orderBy(makeOrderByCondition(sort))
+			.limit(limit)
+			.fetch();
+	}
+
+	private OrderSpecifier<?> makeOrderByCondition(Sort sort) {
+		if (sort == Sort.CREATED_DATE_DESC) {
+			return enrollHistory.enrollId.desc();
+		} else if (sort == Sort.CREATED_DATE_ASC) {
+			return enrollHistory.enrollId.asc();
+		}
+
+		return enrollHistory.enrollId.desc();
+	}
+
+	private Predicate makeWhereCondition(Long enrollId, Sort sort) {
+		if (sort == Sort.CREATED_DATE_DESC && enrollId.equals(0L)) {
+			return null;
+		} else if (sort == Sort.CREATED_DATE_DESC) {
+			return enrollHistory.enrollId.lt(enrollId);
+		} else if (sort == Sort.CREATED_DATE_ASC) {
+			return enrollHistory.enrollId.gt(enrollId);
+		}
+		return enrollHistory.enrollId.lt(enrollId);
+	}
+}

--- a/src/main/java/com/yju/toonovel/domain/user/repository/EnrollCustomRepositoryImpl.java
+++ b/src/main/java/com/yju/toonovel/domain/user/repository/EnrollCustomRepositoryImpl.java
@@ -36,7 +36,8 @@ public class EnrollCustomRepositoryImpl implements EnrollCustomRepository {
 			.join(enrollHistory.user, user)
 			.where(
 				enrollIdCondition(dto.getEnrollId(), dto.getSort()),
-				titleCondition(dto.getNickname())
+				titleCondition(dto.getNickname()),
+				enrollHistory.isApproval.eq(true)
 				)
 			.orderBy(makeOrderByCondition(dto.getSort()))
 			.limit(dto.getLimit())

--- a/src/main/java/com/yju/toonovel/domain/user/service/UserService.java
+++ b/src/main/java/com/yju/toonovel/domain/user/service/UserService.java
@@ -117,8 +117,8 @@ public class UserService {
 			);
 	}
 
-	public List<AuthorListResponseDto> findNewAuthor(AuthorListPaginationRequestDto dto) {
-		return enrollCustomRepository.findAllAuthor(dto.getEnrollId(), dto.getLimit(), dto.getSort());
+	public List<AuthorListResponseDto> findAuthor(AuthorListPaginationRequestDto dto) {
+		return enrollCustomRepository.findAllAuthor(dto);
 	}
 
 	public List<AuthorListResponseDto> findPopularChatRoomAuthor() {

--- a/src/main/java/com/yju/toonovel/domain/user/service/UserService.java
+++ b/src/main/java/com/yju/toonovel/domain/user/service/UserService.java
@@ -12,7 +12,9 @@ import com.yju.toonovel.domain.novel.dto.LikeNovelPaginationResponseDto;
 import com.yju.toonovel.domain.novel.exception.AuthorNotFoundException;
 import com.yju.toonovel.domain.novel.repository.LikeNovelRepository;
 import com.yju.toonovel.domain.novel.repository.NovelRepository;
+import com.yju.toonovel.domain.user.dto.AuthorListPaginationRequestDto;
 import com.yju.toonovel.domain.user.dto.AuthorRegisterRequestDto;
+import com.yju.toonovel.domain.user.dto.AuthorListResponseDto;
 import com.yju.toonovel.domain.user.dto.UserMyProfileResponseDto;
 import com.yju.toonovel.domain.user.dto.UserProfileResponseDto;
 import com.yju.toonovel.domain.user.dto.UserProfileUpdateRequestDto;
@@ -21,19 +23,23 @@ import com.yju.toonovel.domain.user.entity.Role;
 import com.yju.toonovel.domain.user.entity.User;
 import com.yju.toonovel.domain.user.exception.AlreadyAuthorException;
 import com.yju.toonovel.domain.user.exception.UserNotFoundException;
+import com.yju.toonovel.domain.user.repository.EnrollCustomRepository;
 import com.yju.toonovel.domain.user.repository.UserRepository;
 import com.yju.toonovel.global.security.jwt.repository.RefreshTokenRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @RequiredArgsConstructor
 @Service
+@Slf4j
 public class UserService {
 	private final UserRepository userRepository;
 	private final RefreshTokenRepository refreshTokenRepository;
 	private final LikeNovelRepository likeNovelRepository;
 	private final NovelRepository novelRepository;
 	private final EnrollRepository enrollRepository;
+	private final EnrollCustomRepository enrollCustomRepository;
 
 	@Transactional
 	public UserProfileResponseDto getUserProfile(Long id) {
@@ -106,5 +112,9 @@ public class UserService {
 					throw new AuthorNotFoundException();
 				}
 			);
+	}
+
+	public List<AuthorListResponseDto> findNewAuthor(AuthorListPaginationRequestDto dto) {
+		return enrollCustomRepository.findAllAuthor(dto.getEnrollId(), dto.getLimit(), dto.getSort());
 	}
 }

--- a/src/main/java/com/yju/toonovel/domain/user/service/UserService.java
+++ b/src/main/java/com/yju/toonovel/domain/user/service/UserService.java
@@ -8,13 +8,14 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.yju.toonovel.domain.admin.entity.EnrollHistory;
 import com.yju.toonovel.domain.admin.repository.EnrollRepository;
+import com.yju.toonovel.domain.chatting.entity.ChatRoom;
 import com.yju.toonovel.domain.novel.dto.LikeNovelPaginationResponseDto;
 import com.yju.toonovel.domain.novel.exception.AuthorNotFoundException;
 import com.yju.toonovel.domain.novel.repository.LikeNovelRepository;
 import com.yju.toonovel.domain.novel.repository.NovelRepository;
 import com.yju.toonovel.domain.user.dto.AuthorListPaginationRequestDto;
-import com.yju.toonovel.domain.user.dto.AuthorRegisterRequestDto;
 import com.yju.toonovel.domain.user.dto.AuthorListResponseDto;
+import com.yju.toonovel.domain.user.dto.AuthorRegisterRequestDto;
 import com.yju.toonovel.domain.user.dto.UserMyProfileResponseDto;
 import com.yju.toonovel.domain.user.dto.UserProfileResponseDto;
 import com.yju.toonovel.domain.user.dto.UserProfileUpdateRequestDto;
@@ -23,6 +24,7 @@ import com.yju.toonovel.domain.user.entity.Role;
 import com.yju.toonovel.domain.user.entity.User;
 import com.yju.toonovel.domain.user.exception.AlreadyAuthorException;
 import com.yju.toonovel.domain.user.exception.UserNotFoundException;
+import com.yju.toonovel.domain.user.repository.ChatRoomCustomRepository;
 import com.yju.toonovel.domain.user.repository.EnrollCustomRepository;
 import com.yju.toonovel.domain.user.repository.UserRepository;
 import com.yju.toonovel.global.security.jwt.repository.RefreshTokenRepository;
@@ -40,6 +42,7 @@ public class UserService {
 	private final NovelRepository novelRepository;
 	private final EnrollRepository enrollRepository;
 	private final EnrollCustomRepository enrollCustomRepository;
+	private final ChatRoomCustomRepository chatRoomCustomRepository;
 
 	@Transactional
 	public UserProfileResponseDto getUserProfile(Long id) {
@@ -116,5 +119,16 @@ public class UserService {
 
 	public List<AuthorListResponseDto> findNewAuthor(AuthorListPaginationRequestDto dto) {
 		return enrollCustomRepository.findAllAuthor(dto.getEnrollId(), dto.getLimit(), dto.getSort());
+	}
+
+	public List<AuthorListResponseDto> findPopularChatRoomAuthor() {
+		List<ChatRoom> chatRoomList = chatRoomCustomRepository.findByChatRoomMemberCount();
+
+		List<AuthorListResponseDto> result =
+			chatRoomList.stream().map(chatRoom -> {
+				User author = chatRoom.getUser();
+				return new AuthorListResponseDto(author.getUserId(), author.getNickname(), author.getImageUrl());
+			}).collect(Collectors.toList());
+		return result;
 	}
 }


### PR DESCRIPTION
### 📌 개발 개요
- resolve #108 
  <br>

### 💻  작업 및 변경 사항
- 최신작가 리스트 조회 - 가장 최근 승인이 된 작가
- _인기리뷰 - 이미 존재하는 API_
- 인기 채팅방 - 가입된 회원 수가 가장 많은 채팅방
- 작가 검색 기능 - `nickname` 검색으로 지원
  <br>

### ✅ Point
- 어떤 도메인에서 작업해야할지 많이 고민했습니다.
  - (현재는 권한 설정이 없지만) `chatting` 도메인은 접근 권한 설정이 있는 것이 어울린다고 생각합니다
  - 현재 기능은 특별한 목적이라기보단, 페이지를 채우기 위한 기능에 가까우며, `chatting` 도메인은 메신저 기능과 밀접한 연관이 있는 기능만 있으면 좋겠다 느꼈습니다.
  - 기능의 이름? 목적?과는 별개로 실제 반환값은 작가의 정보입니다.
  - 위와 같은 이유로 `user` 도메인에 작성하였습니다
- `novel` 도메인을 봤는데 최대한 많은 데이터를 보내주고 있더군요. 하지만 `user`의 정보는 민감할 수 있기 때문에, 최소한의 데이터만 보내주는 식으로 작업했습니다.
  <br>