### PR TITLE
[FEAT] 작가 ID로 채팅방 가입하는 기능

### DIFF
--- a/src/main/java/com/yju/toonovel/domain/chatting/controller/ChatRoomHttpController.java
+++ b/src/main/java/com/yju/toonovel/domain/chatting/controller/ChatRoomHttpController.java
@@ -56,22 +56,11 @@ public class ChatRoomHttpController {
 		chatRoomService.deleteChatRoom(rid, user.userId);
 	}
 
-	@Operation(summary = "채팅방 가입")
-	@ApiResponse(responseCode = "201", description = "요청 성공")
-	@ApiResponse(responseCode = "400", description = "이미 가입된 채팅방일 때")
-	@ApiResponse(responseCode = "404", description = "해당 채팅방이 없을 때")
-	@PostMapping("{rid}")
-	@ResponseStatus(HttpStatus.CREATED)
-	public void joinChatRoom(@AuthenticationPrincipal JwtAuthentication user,
-		@PathVariable Long rid) {
-		chatRoomService.joinChatRoom(rid, user.userId);
-	}
-
 	@Operation(summary = "userId로 채팅방 가입")
 	@ApiResponse(responseCode = "201", description = "요청 성공")
 	@ApiResponse(responseCode = "400", description = "이미 가입된 채팅방일 때")
 	@ApiResponse(responseCode = "404", description = "해당 채팅방이 없을 때")
-	@PostMapping("/author/{uid}")
+	@PostMapping("{uid}")
 	@ResponseStatus(HttpStatus.CREATED)
 	public void joinChatRoomByUserId(@AuthenticationPrincipal JwtAuthentication user,
 		@PathVariable Long uid) {

--- a/src/main/java/com/yju/toonovel/domain/chatting/controller/ChatRoomHttpController.java
+++ b/src/main/java/com/yju/toonovel/domain/chatting/controller/ChatRoomHttpController.java
@@ -67,6 +67,17 @@ public class ChatRoomHttpController {
 		chatRoomService.joinChatRoom(rid, user.userId);
 	}
 
+	@Operation(summary = "userId로 채팅방 가입")
+	@ApiResponse(responseCode = "201", description = "요청 성공")
+	@ApiResponse(responseCode = "400", description = "이미 가입된 채팅방일 때")
+	@ApiResponse(responseCode = "404", description = "해당 채팅방이 없을 때")
+	@PostMapping("/author/{uid}")
+	@ResponseStatus(HttpStatus.CREATED)
+	public void joinChatRoomByUserId(@AuthenticationPrincipal JwtAuthentication user,
+		@PathVariable Long uid) {
+		chatRoomService.joinChatRoomByUserId(uid, user.userId);
+	}
+
 	@Operation(summary = "채팅방 탈퇴")
 	@ApiResponse(responseCode = "204", description = "요청 성공")
 	@ApiResponse(responseCode = "403", description = "작가가 탈퇴 요청을 했을 때")

--- a/src/main/java/com/yju/toonovel/domain/chatting/service/ChatRoomService.java
+++ b/src/main/java/com/yju/toonovel/domain/chatting/service/ChatRoomService.java
@@ -59,7 +59,7 @@ public class ChatRoomService {
 		ChatRoom result = chatRoomRepository.save(ChatRoom.of(dto.getChatRoomName(), user));
 
 		// 생성 후 바로 셀프 가입
-		joinChatRoom(result.getChatRoomId(), userId);
+		joinChatRoomByUserId(userId, userId);
 	}
 
 	public void deleteChatRoom(Long rid, Long userId) {
@@ -74,25 +74,6 @@ public class ChatRoomService {
 			.orElseThrow(() -> new ChatRoomNotMatchUserException());
 
 		chatRoomRepository.deleteById(rid);
-	}
-
-	@Transactional
-	public void joinChatRoom(Long rid, Long userId) {
-		User user = userRepository.findByUserId(userId)
-			.orElseThrow(() -> new UserNotFoundException());
-
-		ChatRoom chatRoom = chatRoomRepository.findById(rid)
-			.orElseThrow(() -> new ChatRoomNotFoundException());
-
-		// 이미 가입되어 있는지 확인
-		if (chatRoom.getUsers().contains(user)) {
-			throw new ChatRoomAlreadyJoinException();
-		}
-
-		chatRoom.join(user);
-
-		// 엔티티 자체가 변경된 것이 아니라, 엔티티 내부의 컬렉션이 변경된 것이므로 dirty checking에 걸리지 않습니다
-		chatRoomRepository.save(chatRoom);
 	}
 
 	@Transactional

--- a/src/main/java/com/yju/toonovel/domain/chatting/service/ChatRoomService.java
+++ b/src/main/java/com/yju/toonovel/domain/chatting/service/ChatRoomService.java
@@ -95,6 +95,25 @@ public class ChatRoomService {
 		chatRoomRepository.save(chatRoom);
 	}
 
+	@Transactional
+	public void joinChatRoomByUserId(Long uid, Long userId) {
+		User user = userRepository.findByUserId(userId)
+			.orElseThrow(() -> new UserNotFoundException());
+
+		ChatRoom chatRoom = chatRoomRepository.findByAuthorUserId(uid)
+			.orElseThrow(() -> new ChatRoomNotFoundException());
+
+		// 이미 가입되어 있는지 확인
+		if (chatRoom.getUsers().contains(user)) {
+			throw new ChatRoomAlreadyJoinException();
+		}
+
+		chatRoom.join(user);
+
+		// 엔티티 자체가 변경된 것이 아니라, 엔티티 내부의 컬렉션이 변경된 것이므로 dirty checking에 걸리지 않습니다
+		chatRoomRepository.save(chatRoom);
+	}
+
 	public void leaveChatRoom(Long rid, Long userId) {
 		User user = userRepository.findByUserId(userId)
 			.orElseThrow(() -> new UserNotFoundException());
@@ -204,5 +223,6 @@ public class ChatRoomService {
 			chat.getMessage()
 		);
 	}
+
 
 }


### PR DESCRIPTION
### 📌 개발 개요
- resolve #111 

> 작가의 userId로 채팅방에 가입할 수 있는 API
기존 채팅방의 roomId로 가입하는 기능은 있지만, https://github.com/TooNovel/TooNovel-BE/pull/110 에서 필요성이 생겼습니다

  <br>

### 💻  작업 및 변경 사항
- 작가의 `userId`로 채팅방에 가입하는 API
  <br>

### ✅ Point
- 이로 인해 채팅방에 가입하는 API가 2개가 되었습니다(채팅방의 `roomId`, 작가의 `userId`). 리팩토링의 필요성이 보이긴 하지만 당장 급한 일 먼저 처리하겠습니다.. 😢 
  <br>