### PR TITLE
[REFACTOR] 유저 프로필 수정 API 수정

### DIFF
--- a/src/main/java/com/yju/toonovel/domain/admin/service/AdminService.java
+++ b/src/main/java/com/yju/toonovel/domain/admin/service/AdminService.java
@@ -68,7 +68,9 @@ public class AdminService {
 						i.updateUserId(user);
 					});
 				},
-				() -> new AuthorNotFoundException()
+				() -> {
+					throw new AuthorNotFoundException();
+				}
 			);
 		enroll.toggleApproval();
 		user.updateRole(Role.AUTHOR);

--- a/src/main/java/com/yju/toonovel/domain/review/service/ReviewService.java
+++ b/src/main/java/com/yju/toonovel/domain/review/service/ReviewService.java
@@ -46,7 +46,9 @@ public class ReviewService {
 
 		reviewRepository.findReviewByNovelIdAndUserId(user.getUserId(), novel.getNovelId())
 			.ifPresentOrElse(
-				isReview -> new DuplicateReviewException(),
+				isReview -> {
+					throw new DuplicateReviewException();
+				},
 				() -> {
 					reviewRepository.save(dto.dtoToEntity(user, novel));
 				});

--- a/src/main/java/com/yju/toonovel/domain/user/dto/UserProfileUpdateRequestDto.java
+++ b/src/main/java/com/yju/toonovel/domain/user/dto/UserProfileUpdateRequestDto.java
@@ -1,7 +1,6 @@
 package com.yju.toonovel.domain.user.dto;
 
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.Pattern;
 
 import org.hibernate.validator.constraints.Length;
 
@@ -19,22 +18,13 @@ public class UserProfileUpdateRequestDto {
 	@Length(max = 15)
 	@NotBlank
 	private String nickname;
-	@Schema(description = "성별")
-	@NotBlank
-	private String gender;
 	@Schema(description = "유저 프로필 사진")
 	private String imageUrl;
-	@Schema(description = "생년월일")
-	@NotBlank
-	@Pattern(regexp = "(19|20)\\d{2}\\-(0[1-9]|1[012])\\-(0[1-9]|[12][0-9]|3[01])")
-	private String birth;
 
 	@Builder
-	public UserProfileUpdateRequestDto(String nickname, String gender, String imageUrl, String birth) {
+	public UserProfileUpdateRequestDto(String nickname, String imageUrl) {
 		this.nickname = nickname;
-		this.gender = gender;
 		this.imageUrl = imageUrl;
-		this.birth = birth;
 	}
 
 }

--- a/src/main/java/com/yju/toonovel/domain/user/entity/User.java
+++ b/src/main/java/com/yju/toonovel/domain/user/entity/User.java
@@ -73,11 +73,9 @@ public class User extends BaseEntity {
 		this.role = Role.USER;
 	}
 
-	public void updateProfile(String nickname, String imageUrl, String gender, String birth) {
+	public void updateProfile(String nickname, String imageUrl) {
 		this.nickname = nickname;
 		this.imageUrl = imageUrl;
-		this.gender = gender;
-		this.birth = birth;
 	}
 
 	public void updateRole(Role role) {

--- a/src/main/java/com/yju/toonovel/domain/user/service/UserService.java
+++ b/src/main/java/com/yju/toonovel/domain/user/service/UserService.java
@@ -69,8 +69,7 @@ public class UserService {
 	public void updateProfile(Long id, UserProfileUpdateRequestDto requestDto) {
 		User user = userRepository.findByUserId(id)
 			.orElseThrow(() -> new UserNotFoundException());
-		user.updateProfile(requestDto.getNickname(), requestDto.getImageUrl(), requestDto.getGender(),
-			requestDto.getBirth());
+		user.updateProfile(requestDto.getNickname(), requestDto.getImageUrl());
 	}
 
 	@Transactional

--- a/src/main/java/com/yju/toonovel/domain/user/service/UserService.java
+++ b/src/main/java/com/yju/toonovel/domain/user/service/UserService.java
@@ -69,7 +69,7 @@ public class UserService {
 	public void updateProfile(Long id, UserProfileUpdateRequestDto requestDto) {
 		User user = userRepository.findByUserId(id)
 			.orElseThrow(() -> new UserNotFoundException());
-		user.updateProfile(requestDto.getNickname(), requestDto.getGender(), requestDto.getImageUrl(),
+		user.updateProfile(requestDto.getNickname(), requestDto.getImageUrl(), requestDto.getGender(),
 			requestDto.getBirth());
 	}
 

--- a/src/main/java/com/yju/toonovel/global/aws/controller/AwsController.java
+++ b/src/main/java/com/yju/toonovel/global/aws/controller/AwsController.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -28,8 +27,8 @@ public class AwsController {
 
 	@GetMapping("/s3")
 	@ResponseStatus(HttpStatus.OK)
-	public Map<String, Serializable> getPreSignedUrl(@RequestParam String fileName) {
-		return s3Service.getPreSignedUrl(fileName);
+	public Map<String, Serializable> getPreSignedUrl() {
+		return s3Service.getPreSignedUrl();
 	}
 
 }

--- a/src/main/java/com/yju/toonovel/global/aws/service/S3Service.java
+++ b/src/main/java/com/yju/toonovel/global/aws/service/S3Service.java
@@ -1,7 +1,6 @@
 package com.yju.toonovel.global.aws.service;
 
 import java.io.Serializable;
-import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/com/yju/toonovel/global/aws/service/S3Service.java
+++ b/src/main/java/com/yju/toonovel/global/aws/service/S3Service.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -24,8 +25,8 @@ public class S3Service {
 	@Value("${cloud.aws.s3.bucket}")
 	private String bucket;
 
-	public Map<String, Serializable> getPreSignedUrl(String fileName) {
-		String encodedFileName = LocalDateTime.now() + "_" + fileName;
+	public Map<String, Serializable> getPreSignedUrl() {
+		String encodedFileName = UUID.randomUUID().toString();
 		String objectKey = "image/" + encodedFileName;
 
 		Date expiration = new Date();


### PR DESCRIPTION
### 📌 개발 개요
- resolve #109 
  <br>

### 💻  작업 및 변경 사항
- 요구사항 변경에 따른 API 수정
  - 마이페이지 - 프로필 수정 시 성별과 생년월일을 더 이상 받지 않음
- 프로필 이미지 이름을 UUID로 생성
  - `/api/v1/aws/s3` 에서 더 이상 `filename`을 받지 않습니다.
- 변경에 따른 사용되지 않는 import문 삭제
- 던져지지 않는 예외를 발견하여 수정하였습니다.
  <br>

### ✅ Point
- #103 이전에 말씀하신대로 API를 변경하였습니다.
  <br>