### PR TITLE
[FEAT] Reply 조회 기능 추가

### DIFF
--- a/src/main/java/com/yju/toonovel/domain/chatting/controller/ChatRoomHttpController.java
+++ b/src/main/java/com/yju/toonovel/domain/chatting/controller/ChatRoomHttpController.java
@@ -1,7 +1,9 @@
 package com.yju.toonovel.domain.chatting.controller;
 
+import java.time.LocalDate;
 import java.util.List;
 
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.yju.toonovel.domain.chatting.dto.ChatDto;
 import com.yju.toonovel.domain.chatting.dto.ChatRoomCreateRequestDto;
 import com.yju.toonovel.domain.chatting.dto.ChatRoomResponseDto;
+import com.yju.toonovel.domain.chatting.dto.ReplyDto;
 import com.yju.toonovel.domain.chatting.service.ChatRoomService;
 import com.yju.toonovel.global.security.jwt.JwtAuthentication;
 
@@ -87,16 +90,29 @@ public class ChatRoomHttpController {
 		return chatRoomService.getAllChatRoom(user.userId);
 	}
 
-	@Operation(summary = "채팅 목록 조회")
+	@Operation(summary = "채팅 목록 조회 (요청 날짜 형식 yyyy-MM-dd)")
 	@ApiResponse(responseCode = "200", description = "요청 성공")
 	@ApiResponse(responseCode = "404", description = "해당 채팅방이 없을 때")
 	@ApiResponse(responseCode = "409", description = "요청한 유저가 해당 채팅방에 가입되어 있지 않을 때")
 	@GetMapping("{rid}")
 	@ResponseStatus(HttpStatus.OK)
-	public List<ChatDto> getChatListByAuthor(
+	public List<ChatDto> getChatList(
 		@AuthenticationPrincipal JwtAuthentication user,
 		@PathVariable("rid") Long rid,
-		@RequestParam(required = false) Long chatId) {
-		return chatRoomService.getChatList(user.userId, rid, chatId);
+		@RequestParam(value = "date", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+		return chatRoomService.getChatList(user.userId, rid, date);
+	}
+
+	@Operation(summary = "답장 목록 조회 (요청 날짜 형식 yyyy-MM-dd)")
+	@ApiResponse(responseCode = "200", description = "요청 성공")
+	@ApiResponse(responseCode = "404", description = "해당 채팅방이 없을 때")
+	@ApiResponse(responseCode = "409", description = "요청한 유저가 해당 채팅방에 가입되어 있지 않을 때")
+	@GetMapping("/reply/{rid}")
+	@ResponseStatus(HttpStatus.OK)
+	public List<ReplyDto> getReplyList(
+		@AuthenticationPrincipal JwtAuthentication user,
+		@PathVariable("rid") Long rid,
+		@RequestParam(value = "date", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+		return chatRoomService.getReplyList(user.userId, rid, date);
 	}
 }

--- a/src/main/java/com/yju/toonovel/domain/chatting/dto/ChatDto.java
+++ b/src/main/java/com/yju/toonovel/domain/chatting/dto/ChatDto.java
@@ -1,5 +1,7 @@
 package com.yju.toonovel.domain.chatting.dto;
 
+import java.time.LocalDateTime;
+
 import javax.validation.constraints.NotBlank;
 
 import org.hibernate.validator.constraints.Length;
@@ -29,20 +31,36 @@ public class ChatDto {
 	@Length(max = 300)
 	@Schema(description = "채팅 내용")
 	private String message;
-
 	@Schema(description = "메시지 필터링 결과 'ok' or 'bad'")
 	private String filterResult;
+	@Schema(description = "채팅을 보낸 시간")
+	private LocalDateTime createdDate;
 
 	@Builder
-	public ChatDto(Long chatId, String senderName, Long senderId, boolean isCreator, String message) {
+	public ChatDto(
+		Long chatId,
+		String senderName,
+		Long senderId,
+		boolean isCreator,
+		String message,
+		LocalDateTime createdDate
+	) {
 		this.chatId = chatId;
 		this.senderName = senderName;
 		this.senderId = senderId;
 		this.isCreator = isCreator;
 		this.message = message;
+		this.createdDate = createdDate;
 	}
 
-	public static ChatDto of(Long chatId, String senderName, Long senderId, boolean isCreator, String message) {
+	public static ChatDto of(
+		Long chatId,
+		String senderName,
+		Long senderId,
+		boolean isCreator,
+		String message,
+		LocalDateTime createdDate
+	) {
 		// chatId = no offset 페이징용, Reply시 식별용
 		// senderName = 채팅방에 발신자 닉네임 표시
 		// senderId = 수신자가 자신이 보낸 메세지인지 구분
@@ -54,6 +72,7 @@ public class ChatDto {
 			.senderId(senderId)
 			.isCreator(isCreator)
 			.message(message)
+			.createdDate(createdDate)
 			.build();
 	}
 }

--- a/src/main/java/com/yju/toonovel/domain/chatting/dto/ReplyDto.java
+++ b/src/main/java/com/yju/toonovel/domain/chatting/dto/ReplyDto.java
@@ -1,5 +1,7 @@
 package com.yju.toonovel.domain.chatting.dto;
 
+import java.time.LocalDateTime;
+
 import javax.validation.constraints.NotBlank;
 
 import org.hibernate.validator.constraints.Length;
@@ -26,6 +28,8 @@ public class ReplyDto {
 	@Length(max = 300)
 	@Schema(description = "답장 내용")
 	private String replyMessage;
+	@Schema(description = "답장을 보낸 시간")
+	private LocalDateTime createdDate;
 	@Schema(description = "원문 채팅의 채팅 번호")
 	private Long chatId;
 	@Schema(description = "원문 채팅의 채팅 내용")

--- a/src/main/java/com/yju/toonovel/domain/chatting/repository/ChatCustomRepository.java
+++ b/src/main/java/com/yju/toonovel/domain/chatting/repository/ChatCustomRepository.java
@@ -1,5 +1,6 @@
 package com.yju.toonovel.domain.chatting.repository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import com.yju.toonovel.domain.chatting.entity.Chat;
@@ -9,11 +10,11 @@ import com.yju.toonovel.domain.user.entity.User;
 public interface ChatCustomRepository {
 	List<Chat> findAllByChatRoomToAuthor(ChatRoom chatRoom);
 
-	List<Chat> findAllByChatRoomAndChatIdToAuthor(ChatRoom chatRoom, Long chatId);
+	List<Chat> findAllByChatRoomAndDateToAuthor(ChatRoom chatRoom, LocalDate date);
 
 	List<Chat> findAllByChatRoomToUser(ChatRoom chatRoom, Long userId, User author);
 
-	List<Chat> findAllByChatRoomAndChatIdToUser(ChatRoom chatRoom, Long userId, User author, Long chatId);
+	List<Chat> findAllByChatRoomAndDateToUser(ChatRoom chatRoom, Long userId, User author, LocalDate date);
 
 	List<Chat> findRecentChatByChatRoomAndUser(ChatRoom chatRoom, Long userId, long limit);
 }

--- a/src/main/java/com/yju/toonovel/domain/chatting/repository/ChatCustomRepositoryImpl.java
+++ b/src/main/java/com/yju/toonovel/domain/chatting/repository/ChatCustomRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.yju.toonovel.domain.chatting.repository;
 
 import static com.yju.toonovel.domain.chatting.entity.QChat.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import org.springframework.stereotype.Repository;
@@ -25,20 +26,18 @@ public class ChatCustomRepositoryImpl implements ChatCustomRepository {
 			.selectFrom(chat)
 			.where(chat.chatRoom.eq(chatRoom))
 			.orderBy(chat.chatId.desc())
-			.limit(30)
 			.fetch();
 	}
 
 	@Override
-	public List<Chat> findAllByChatRoomAndChatIdToAuthor(ChatRoom chatRoom, Long chatId) {
+	public List<Chat> findAllByChatRoomAndDateToAuthor(ChatRoom chatRoom, LocalDate date) {
 		return jpaQueryFactory
 			.selectFrom(chat)
 			.where(
 				chat.chatRoom.eq(chatRoom),
-				chat.chatId.lt(chatId)
+				chat.createdDate.between(date.atStartOfDay(), date.plusDays(1).atStartOfDay())
 			)
 			.orderBy(chat.chatId.desc())
-			.limit(30)
 			.fetch();
 	}
 
@@ -52,22 +51,20 @@ public class ChatCustomRepositoryImpl implements ChatCustomRepository {
 					.or(chat.user.eq(author))
 			)
 			.orderBy(chat.chatId.desc())
-			.limit(30)
 			.fetch();
 	}
 
 	@Override
-	public List<Chat> findAllByChatRoomAndChatIdToUser(ChatRoom chatRoom, Long userId, User author, Long chatId) {
+	public List<Chat> findAllByChatRoomAndDateToUser(ChatRoom chatRoom, Long userId, User author, LocalDate date) {
 		return jpaQueryFactory
 			.selectFrom(chat)
 			.where(
 				chat.chatRoom.eq(chatRoom),
-				chat.chatId.lt(chatId),
+				chat.createdDate.between(date.atStartOfDay(), date.plusDays(1).atStartOfDay()),
 				chat.user.userId.eq(userId)
 					.or(chat.user.eq(author))
 			)
 			.orderBy(chat.chatId.desc())
-			.limit(30)
 			.fetch();
 	}
 

--- a/src/main/java/com/yju/toonovel/domain/chatting/repository/ReplyCustomRepository.java
+++ b/src/main/java/com/yju/toonovel/domain/chatting/repository/ReplyCustomRepository.java
@@ -1,0 +1,11 @@
+package com.yju.toonovel.domain.chatting.repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.yju.toonovel.domain.chatting.dto.ReplyDto;
+import com.yju.toonovel.domain.chatting.entity.ChatRoom;
+
+public interface ReplyCustomRepository {
+	List<ReplyDto> findAllByChatRoomAndDate(ChatRoom chatRoom, LocalDate date);
+}

--- a/src/main/java/com/yju/toonovel/domain/chatting/repository/ReplyCustomRepositoryImpl.java
+++ b/src/main/java/com/yju/toonovel/domain/chatting/repository/ReplyCustomRepositoryImpl.java
@@ -1,0 +1,57 @@
+package com.yju.toonovel.domain.chatting.repository;
+
+import static com.yju.toonovel.domain.chatting.entity.QChat.*;
+import static com.yju.toonovel.domain.chatting.entity.QReply.*;
+import static com.yju.toonovel.domain.user.entity.QUser.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.yju.toonovel.domain.chatting.dto.ReplyDto;
+import com.yju.toonovel.domain.chatting.entity.ChatRoom;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ReplyCustomRepositoryImpl implements ReplyCustomRepository {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public List<ReplyDto> findAllByChatRoomAndDate(ChatRoom chatRoom, LocalDate date) {
+		return jpaQueryFactory
+			.select(
+				Projections.fields(
+					ReplyDto.class,
+					reply.replyId,
+					reply.user.userId.as("senderId"),
+					reply.user.nickname.as("senderName"),
+					reply.message.as("replyMessage"),
+					reply.createdDate,
+					reply.chat.chatId,
+					reply.chat.message.as("userMessage"),
+					reply.chat.user.nickname.as("userName")
+				)
+			)
+			.from(reply)
+			.join(reply.chat, chat)
+			.join(reply.user, user)
+			.join(reply.chat.user, user)
+			.where(
+				reply.chatRoom.eq(chatRoom),
+				makeWhereCondition(date)
+				)
+			.fetch();
+	}
+
+	private Predicate makeWhereCondition(LocalDate date) {
+		return (date == null) ? null : reply.createdDate.between(date.atStartOfDay(), date.plusDays(1).atStartOfDay());
+	}
+
+}

--- a/src/main/java/com/yju/toonovel/domain/chatting/service/ChatService.java
+++ b/src/main/java/com/yju/toonovel/domain/chatting/service/ChatService.java
@@ -86,6 +86,7 @@ public class ChatService {
 		dto.setSenderName(user.getNickname());
 		dto.setCreator(isCreator);
 		dto.setFilterResult(response.getFilteredResult());
+		dto.setCreatedDate(chat.getCreatedDate());
 	}
 
 	public FilterChatResponseDto filterChat(String message) {
@@ -130,6 +131,7 @@ public class ChatService {
 		dto.setReplyId(reply.getReplyId());
 		dto.setSenderName(user.getNickname());
 		dto.setUserName(chat.getUser().getNickname());
+		dto.setCreatedDate(chat.getCreatedDate());
 	}
 
 	private void limitCheck(User user, ChatRoom chatRoom, long limit) {


### PR DESCRIPTION
### 📌 개발 개요
- resolve #119

> 작가가 독자의 메세지 보낸 답장인 Reply 조회 기능 추가
  <br>

### 💻  작업 및 변경 사항
- 채팅 조회 방식 변경 `최근 30개` -> `일자별 조회`
  - ex) `date=2023-06-18`을 쿼리스트링으로 전달하면 해당 날짜의 채팅(답장)이 조회되는 방식
- `ChatDto`, `ReplyDto`에 작성 시간 추가 - DB 입력 시간 기준
- Reply 조회 기능 추가
  <br>

### ✅ Point
- 프론트엔드에서는 채팅을 조회하기 위하여 Chat 조회 요청과, Reply 조회 요청을 따로 해야하도록 구성하였습니다.
  - 이렇게 구성한 이유는 데이터 형식이 다르므로 하나의 요청으로 처리할 경우 백엔드, 프론트엔드 모두 취급 난이도가 상승하기 때문입니다.
- 현재 n+1 문제는 없는 것으로 보이지만, 채팅 조회 한번에 2번이나 요청이 이루어지는 구조상 쿼리 횟수가 많습니다. 추후에 개선을 시도하도록 하겠습니다
  <br>