### PR TITLE
[BUG] [REFACTOR] 작가 검색 시 무한 스크롤 문제, 채팅방 처음 조회 시 API 변경

### DIFF
--- a/src/main/java/com/yju/toonovel/domain/chatting/repository/ChatCustomRepositoryImpl.java
+++ b/src/main/java/com/yju/toonovel/domain/chatting/repository/ChatCustomRepositoryImpl.java
@@ -24,7 +24,12 @@ public class ChatCustomRepositoryImpl implements ChatCustomRepository {
 	public List<Chat> findAllByChatRoomToAuthor(ChatRoom chatRoom) {
 		return jpaQueryFactory
 			.selectFrom(chat)
-			.where(chat.chatRoom.eq(chatRoom))
+			.where(
+				chat.chatRoom.eq(chatRoom),
+				chat.createdDate.between(
+					LocalDate.now().minusDays(7).atStartOfDay(), LocalDate.now().plusDays(1).atStartOfDay()
+				)
+			)
 			.orderBy(chat.chatId.desc())
 			.fetch();
 	}
@@ -48,7 +53,10 @@ public class ChatCustomRepositoryImpl implements ChatCustomRepository {
 			.where(
 				chat.chatRoom.eq(chatRoom),
 				chat.user.userId.eq(userId)
-					.or(chat.user.eq(author))
+					.or(chat.user.eq(author)),
+				chat.createdDate.between(
+					LocalDate.now().minusDays(7).atStartOfDay(), LocalDate.now().plusDays(1).atStartOfDay()
+				)
 			)
 			.orderBy(chat.chatId.desc())
 			.fetch();
@@ -74,7 +82,10 @@ public class ChatCustomRepositoryImpl implements ChatCustomRepository {
 			.selectFrom(chat)
 			.where(
 				chat.chatRoom.eq(chatRoom),
-				chat.user.userId.eq(userId)
+				chat.user.userId.eq(userId),
+				chat.createdDate.between(
+					LocalDate.now().minusDays(7).atStartOfDay(), LocalDate.now().plusDays(1).atStartOfDay()
+				)
 			)
 			.orderBy(chat.chatId.desc())
 			.limit(limit)

--- a/src/main/java/com/yju/toonovel/domain/chatting/repository/ReplyCustomRepositoryImpl.java
+++ b/src/main/java/com/yju/toonovel/domain/chatting/repository/ReplyCustomRepositoryImpl.java
@@ -51,7 +51,10 @@ public class ReplyCustomRepositoryImpl implements ReplyCustomRepository {
 	}
 
 	private Predicate makeWhereCondition(LocalDate date) {
-		return (date == null) ? null : reply.createdDate.between(date.atStartOfDay(), date.plusDays(1).atStartOfDay());
+		return (date == null)
+			? reply.createdDate.between(
+				LocalDate.now().minusDays(7).atStartOfDay(), LocalDate.now().plusDays(1).atStartOfDay()
+		)
+			: reply.createdDate.between(date.atStartOfDay(), date.plusDays(1).atStartOfDay());
 	}
-
 }

--- a/src/main/java/com/yju/toonovel/domain/user/dto/AuthorListResponseDto.java
+++ b/src/main/java/com/yju/toonovel/domain/user/dto/AuthorListResponseDto.java
@@ -18,4 +18,7 @@ public class AuthorListResponseDto {
 
 	@Schema(description = "작가의 프로필 사진")
 	private String imageUrl;
+
+	@Schema(description = "페이징용 신청 ID")
+	private Long enrollId;
 }

--- a/src/main/java/com/yju/toonovel/domain/user/repository/EnrollCustomRepositoryImpl.java
+++ b/src/main/java/com/yju/toonovel/domain/user/repository/EnrollCustomRepositoryImpl.java
@@ -30,7 +30,8 @@ public class EnrollCustomRepositoryImpl implements EnrollCustomRepository {
 				AuthorListResponseDto.class,
 				enrollHistory.user.userId,
 				enrollHistory.user.nickname,
-				enrollHistory.user.imageUrl
+				enrollHistory.user.imageUrl,
+				enrollHistory.enrollId
 			))
 			.from(enrollHistory)
 			.join(enrollHistory.user, user)

--- a/src/main/java/com/yju/toonovel/domain/user/service/UserService.java
+++ b/src/main/java/com/yju/toonovel/domain/user/service/UserService.java
@@ -126,7 +126,7 @@ public class UserService {
 		List<AuthorListResponseDto> result =
 			chatRoomList.stream().map(chatRoom -> {
 				User author = chatRoom.getUser();
-				return new AuthorListResponseDto(author.getUserId(), author.getNickname(), author.getImageUrl());
+				return new AuthorListResponseDto(author.getUserId(), author.getNickname(), author.getImageUrl(), null);
 			}).collect(Collectors.toList());
 		return result;
 	}


### PR DESCRIPTION
### 📌 개발 개요
- resolve #126
> 작가 검색 시 무한 스크롤이 비정상적인 현상

- resolve #129 
> 채팅방 처음 접속 시 이전 채팅, 답장 조회 API 변경

  <br>

### 💻  작업 및 변경 사항
- 프론트엔드에서 검색 기준을 잡을 수 있도록 응답 dto에 `enrollId` 추가
- 조회 일자를 null로 전송하면 최근 7일간의 채팅/답장 반환
  <br>
