### PR TITLE
[BUG] 작가 통계 조회 버그 발생

### DIFF
--- a/src/main/java/com/yju/toonovel/domain/admin/dto/EnrollListResponseDto.java
+++ b/src/main/java/com/yju/toonovel/domain/admin/dto/EnrollListResponseDto.java
@@ -21,7 +21,7 @@ public class EnrollListResponseDto {
 	private Long userId;
 	@Schema(description = "신청확인 테이블에 존재하는지 체크할 신청번호")
 	private Long enrollId;
-	@Schema(description = "닉네임")
+	@Schema(description = "유저가 신청한 작가 닉네임")
 	@Length(max = 15)
 	@NotBlank
 	private String nickname;

--- a/src/main/java/com/yju/toonovel/domain/admin/entity/EnrollHistory.java
+++ b/src/main/java/com/yju/toonovel/domain/admin/entity/EnrollHistory.java
@@ -24,6 +24,8 @@ public class EnrollHistory extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long enrollId;
 
+	private String nickname;
+
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")
 	private User user;
@@ -32,13 +34,15 @@ public class EnrollHistory extends BaseEntity {
 
 
 	@Builder
-	public EnrollHistory(User user, boolean isApproval) {
+	public EnrollHistory(String nickname, User user, boolean isApproval) {
+		this.nickname = nickname;
 		this.user = user;
 		this.isApproval = isApproval;
 	}
 
-	public static EnrollHistory of(User user) {
+	public static EnrollHistory of(String nickname, User user) {
 		return EnrollHistory.builder()
+			.nickname(nickname)
 			.user(user)
 			.build();
 	}

--- a/src/main/java/com/yju/toonovel/domain/admin/repository/AdminRepositoryImpl.java
+++ b/src/main/java/com/yju/toonovel/domain/admin/repository/AdminRepositoryImpl.java
@@ -47,7 +47,7 @@ public class AdminRepositoryImpl implements AdminRepositoryCustom {
 				Projections.fields(
 					EnrollListResponseDto.class,
 					enrollHistory.user.userId, enrollHistory.enrollId,
-					enrollHistory.user.nickname, enrollHistory.isApproval,
+					enrollHistory.nickname, enrollHistory.isApproval,
 					enrollHistory.createdDate
 				)
 			)

--- a/src/main/java/com/yju/toonovel/domain/statistics/repository/StatisticsRepository.java
+++ b/src/main/java/com/yju/toonovel/domain/statistics/repository/StatisticsRepository.java
@@ -10,6 +10,7 @@ import com.yju.toonovel.domain.novel.entity.Novel;
 
 public interface StatisticsRepository extends JpaRepository<Novel, Long> {
 
+	//작가가 쓴 작품인지 검증 - 추후 작가인지 권한도 검증할 예정
 	@Query("select n from Novel n where n.novelId = :nid and n.user.userId = :uid")
 	Optional<Novel> findNovelByUserIdAndNovelId(@Param("nid") Long nid, @Param("uid") Long uid);
 }

--- a/src/main/java/com/yju/toonovel/domain/statistics/repository/StatisticsRepository.java
+++ b/src/main/java/com/yju/toonovel/domain/statistics/repository/StatisticsRepository.java
@@ -10,7 +10,6 @@ import com.yju.toonovel.domain.novel.entity.Novel;
 
 public interface StatisticsRepository extends JpaRepository<Novel, Long> {
 
-	//작가가 쓴 작품인지 검증 - 추후 작가인지 권한도 검증할 예정
 	@Query("select n from Novel n where n.novelId = :nid and n.user.userId = :uid")
 	Optional<Novel> findNovelByUserIdAndNovelId(@Param("nid") Long nid, @Param("uid") Long uid);
 }

--- a/src/main/java/com/yju/toonovel/domain/statistics/repository/StatisticsRepository.java
+++ b/src/main/java/com/yju/toonovel/domain/statistics/repository/StatisticsRepository.java
@@ -11,6 +11,6 @@ import com.yju.toonovel.domain.novel.entity.Novel;
 public interface StatisticsRepository extends JpaRepository<Novel, Long> {
 
 	//작가가 쓴 작품인지 검증 - 추후 작가인지 권한도 검증할 예정
-	@Query("select n from Novel n where n.novelId = :nid and n.author = :nick")
-	Optional<Novel> findNovelByUserIdAndNovelId(@Param("nid") Long nid, @Param("nick") String nick);
+	@Query("select n from Novel n where n.novelId = :nid and n.user.userId = :uid")
+	Optional<Novel> findNovelByUserIdAndNovelId(@Param("nid") Long nid, @Param("uid") Long uid);
 }

--- a/src/main/java/com/yju/toonovel/domain/statistics/service/StatisticsService.java
+++ b/src/main/java/com/yju/toonovel/domain/statistics/service/StatisticsService.java
@@ -36,7 +36,7 @@ public class StatisticsService {
 		novelRepository.findByNovelId(nid)
 			.orElseThrow(() -> new NovelNotFoundException());
 
-		Novel novel = statisticsRepository.findNovelByUserIdAndNovelId(nid, user.getNickname())
+		Novel novel = statisticsRepository.findNovelByUserIdAndNovelId(nid, user.getUserId())
 			.orElseThrow(()-> new NovelNotMatchAuthorException());
 
 		return statisticRepositoryImpl.getGenderStatistic(novel.getNovelId());
@@ -50,7 +50,7 @@ public class StatisticsService {
 		novelRepository.findByNovelId(nid)
 			.orElseThrow(() -> new NovelNotFoundException());
 
-		Novel novel = statisticsRepository.findNovelByUserIdAndNovelId(nid, user.getNickname())
+		Novel novel = statisticsRepository.findNovelByUserIdAndNovelId(nid, user.getUserId())
 			.orElseThrow(()-> new NovelNotMatchAuthorException());
 
 		return statisticRepositoryImpl.getAgeStatistic(novel.getNovelId());

--- a/src/main/java/com/yju/toonovel/domain/user/service/UserService.java
+++ b/src/main/java/com/yju/toonovel/domain/user/service/UserService.java
@@ -114,7 +114,7 @@ public class UserService {
 		novelRepository.findByAuthor(dto.getNickname())
 			.ifPresentOrElse(
 				isAuthor -> {
-					enrollRepository.save(EnrollHistory.of(user));
+					enrollRepository.save(EnrollHistory.of(dto.getNickname(), user));
 				},
 				() -> {
 					throw new AuthorNotFoundException();


### PR DESCRIPTION
### 📌 개발 개요
- resolve #128 
  <br>

### 💻  작업 및 변경 사항
- 작가 신청 승인 시 버그 발생
  - 회원가입 시 입력한 닉네임, 작가 신청할 때 입력한 닉네임 다를 경우 버그 발생
  - 이유는 기존 코드는 회원가입시 입력한 유저의 닉네임을 사용하고 있었기 때문이었습니다.
  - `enrollHistory` 테이블에 `nickname` 컬럼을 추가하였습니다.
- 내 작품 통계 조회 시 버그 발생
  - 이 버그 또한 회원가입시 입력한 닉네임과 `novel` 테이블의 `author` 칼럼과 비교하려 했기 때문에 버그가 발생했습니다.
  - 해결은 닉네임으로 조회하는것이 아닌 작가 승인이 되었을 때 `novel` 테이블에 업데이트된 userId와 `user`테이블의 `userId`를 조회하는 것으로 해결했습니다.
  <br>

### ✅ Point
- `enrollHistory` 테이블에 `nickname` 컬럼이 추가되었습니다.                             
  <br>