### PR TITLE
[FEAT] 기본 프로필 이미지 추가

### DIFF
--- a/src/main/java/com/yju/toonovel/domain/user/entity/User.java
+++ b/src/main/java/com/yju/toonovel/domain/user/entity/User.java
@@ -24,6 +24,8 @@ import lombok.NoArgsConstructor;
 @SQLDelete(sql = "UPDATE user SET deleted = true where user_id=?")
 public class User extends BaseEntity {
 
+	public static final String DEFAULT_IMAGE_URL = "https://toonovel-image-bucket.s3.ap-northeast-2.amazonaws.com/image/default_image.png";
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long userId;
@@ -55,10 +57,9 @@ public class User extends BaseEntity {
 	private boolean deleted;
 
 	@Builder
-	public User(String nickname, String imageUrl, Provider provider, String oauthId,
-		Role role, String gender, String birth) {
+	public User(String nickname, Provider provider, String oauthId, Role role, String gender, String birth) {
 		this.nickname = nickname;
-		this.imageUrl = imageUrl;
+		this.imageUrl = DEFAULT_IMAGE_URL;
 		this.provider = provider;
 		this.oauthId = oauthId;
 		this.role = role;


### PR DESCRIPTION
### 📌 개발 개요
- resolve #134 
- 회원 가입 시, 기본 프로필 이미지 적용
  <br>

### 💻  작업 및 변경 사항
- `User` 엔티티안에 `DEFAULT_IMAGE_URL` 를 추가하였습니다.
- 현재 `User` 를 생성하는 빌더가 `OAuthAttributes` 의 toEntity를 통해서만 구현되어 있기 때문에 가입 시 기본 프로필 이미지로 적용됩니다.
  <br>

### ✅ Point
- 마지막까지 파이팅입니다 👍                           
  <br>