### PR TITLE
[BUG] no-offset 페이징 관련 버그

### DIFF
--- a/src/main/java/com/yju/toonovel/domain/novel/dto/NovelDetailResponseDto.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/dto/NovelDetailResponseDto.java
@@ -30,7 +30,7 @@ public class NovelDetailResponseDto {
 	@Schema(description = "리뷰 수")
 	private long reviewCount;
 	@Schema(description = "소설 평점")
-	private Double grade;
+	private double grade;
 	@Schema(description = "서비스 중인 플랫폼 리스트")
 	private List<PlatformResponseDto> platforms = new ArrayList<>();
 	@Schema(description = "소설 표지")

--- a/src/main/java/com/yju/toonovel/domain/novel/dto/NovelPaginationRequestDto.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/dto/NovelPaginationRequestDto.java
@@ -18,15 +18,27 @@ public class NovelPaginationRequestDto {
 	private String author;
 	@Schema(description = "장르")
 	private Genre genre;
-	@Schema(description = "정렬 기준", defaultValue = "CREATED_DATE_DESC")
+	@Schema(description = "좋아요 수")
+	private Long likeCount;
+	@Schema(description = "리뷰 수")
+	private Long reviewCount;
+	@Schema(description = "소설 평점")
+	private Double grade;
+	@Schema(description = "소설 추가 일자")
+	private String createdDate;
+	@Schema(description = "정렬 기준")
 	private Sort sort;
 
-	public NovelPaginationRequestDto(Long novelId, String title, String author, Genre genre, Sort sort) {
+	public NovelPaginationRequestDto(Long novelId, String title, String author, Genre genre, Long likeCount,
+		Long reviewCount, Double grade, String createdDate, Sort sort) {
 		this.novelId = novelId;
 		this.title = title;
 		this.author = author;
 		this.genre = genre;
+		this.likeCount = likeCount;
+		this.reviewCount = reviewCount;
+		this.grade = grade;
+		this.createdDate = createdDate;
 		this.sort = sort == null ? Sort.CREATED_DATE_DESC : sort;
 	}
-
 }

--- a/src/main/java/com/yju/toonovel/domain/novel/dto/NovelPaginationResponseDto.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/dto/NovelPaginationResponseDto.java
@@ -1,5 +1,8 @@
 package com.yju.toonovel.domain.novel.dto;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 import com.yju.toonovel.domain.novel.entity.Genre;
 import com.yju.toonovel.domain.novel.entity.Novel;
 
@@ -20,17 +23,19 @@ public class NovelPaginationResponseDto {
 	@Schema(description = "장르")
 	private Genre genre;
 	@Schema(description = "소설 평점")
-	private Double grade;
+	private double grade;
 	@Schema(description = "리뷰 수")
 	private Long reviewCount;
 	@Schema(description = "좋아요 수")
 	private Long likeCount;
+	@Schema(description = "소설 추가 일자")
+	private String createdDate;
 	@Schema(description = "소설 표지")
 	private String image;
 
 	@Builder
 	public NovelPaginationResponseDto(Long novelId, String title, String author, Genre genre, Double grade,
-		Long reviewCount, Long likeCount, String image) {
+		Long reviewCount, Long likeCount, LocalDateTime createdDate, String image) {
 		this.novelId = novelId;
 		this.title = title;
 		this.author = author;
@@ -38,6 +43,7 @@ public class NovelPaginationResponseDto {
 		this.grade = grade;
 		this.reviewCount = reviewCount;
 		this.likeCount = likeCount;
+		this.createdDate = createdDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
 		this.image = image;
 	}
 
@@ -50,6 +56,7 @@ public class NovelPaginationResponseDto {
 			novel.getGrade(),
 			novel.getReviewCount(),
 			novel.getLikeCount(),
+			novel.getCreatedDate(),
 			novel.getImage()
 		);
 	}

--- a/src/main/java/com/yju/toonovel/domain/novel/entity/Novel.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/entity/Novel.java
@@ -51,7 +51,7 @@ public class Novel extends BaseEntity {
 	private long likeCount;
 
 	@Basic(fetch = FetchType.LAZY)
-	@Formula("(SELECT FORMAT(AVG(r.review_grade), 1) FROM review r WHERE r.novel_id = novel_id)")
+	@Formula("(SELECT COALESCE(FORMAT(AVG(r.review_grade), 1), 0) FROM review r WHERE r.novel_id = novel_id)")
 	private Double grade;
 
 	@Basic(fetch = FetchType.LAZY)

--- a/src/main/java/com/yju/toonovel/domain/novel/repository/NovelCustomRepositoryImpl.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/repository/NovelCustomRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.yju.toonovel.domain.novel.repository;
 
 import static com.yju.toonovel.domain.novel.entity.QNovel.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.stereotype.Repository;
@@ -33,12 +34,14 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
 				ltNovelId(requestDto.getNovelId()),
 				eqGenre(requestDto.getGenre()),
 				eqTitle(requestDto.getTitle()),
-				eqAuthor(requestDto.getAuthor())
+				eqAuthor(requestDto.getAuthor()),
+				cursorCreatedDateAndNovelId(requestDto.getCreatedDate(), requestDto.getNovelId()),
+				cursorReviewCountAndNovelId(requestDto.getReviewCount(), requestDto.getNovelId()),
+				cursorLikeCountAndNovelId(requestDto.getLikeCount(), requestDto.getNovelId()),
+				cursorGradeAndNovelId(requestDto.getGrade(), requestDto.getNovelId())
 			)
 			.limit(30)
-			.orderBy(
-				getOrderSpecifier(requestDto.getSort())
-			)
+			.orderBy(getOrderSpecifier(requestDto.getSort()), novel.novelId.desc())
 			.fetch();
 	}
 
@@ -50,6 +53,47 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
 			.fetch();
 	}
 
+	private BooleanExpression cursorCreatedDateAndNovelId(String createdDate, Long novelId) {
+		if (createdDate == null || novelId == null) {
+			return null;
+		}
+
+		LocalDateTime parsedDate = LocalDateTime.parse(createdDate + "T00:00:00");
+		return novel.createdDate.eq(parsedDate)
+			.and(novel.novelId.lt(novelId))
+			.or(novel.createdDate.lt(parsedDate));
+	}
+
+	private BooleanExpression cursorReviewCountAndNovelId(Long reviewCount, Long novelId) {
+		if (reviewCount == null || novelId == null) {
+			return null;
+		}
+
+		return novel.reviewCount.eq(reviewCount)
+			.and(novel.novelId.lt(novelId))
+			.or(novel.reviewCount.lt(reviewCount));
+	}
+
+	private BooleanExpression cursorLikeCountAndNovelId(Long likeCount, Long novelId) {
+		if (likeCount == null || novelId == null) {
+			return null;
+		}
+
+		return novel.likeCount.eq(likeCount)
+			.and(novel.novelId.lt(novelId))
+			.or(novel.likeCount.lt(likeCount));
+	}
+
+	private BooleanExpression cursorGradeAndNovelId(Double grade, Long novelId) {
+		if (grade == null || novelId == null) {
+			return null;
+		}
+
+		return novel.grade.eq(grade)
+			.and(novel.novelId.lt(novelId))
+			.or(novel.grade.lt(grade));
+	}
+
 	@Override
 	public List<Novel> findNovelByAuthor(NovelPaginationRequestDto requestDto, Long userId) {
 		return jpaQueryFactory
@@ -59,9 +103,6 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
 				ltNovelId(requestDto.getNovelId())
 			)
 			.limit(30)
-			.orderBy(
-				getOrderSpecifier(requestDto.getSort())
-			)
 			.fetch();
 	}
 

--- a/src/main/java/com/yju/toonovel/domain/novel/repository/NovelCustomRepositoryImpl.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/repository/NovelCustomRepositoryImpl.java
@@ -58,7 +58,7 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
 			return null;
 		}
 
-		LocalDateTime parsedDate = LocalDateTime.parse(createdDate + "T00:00:00");
+		LocalDateTime parsedDate = LocalDateTime.parse(createdDate + "T00:00:00").plusDays(1);
 		return novel.createdDate.eq(parsedDate)
 			.and(novel.novelId.lt(novelId))
 			.or(novel.createdDate.lt(parsedDate));


### PR DESCRIPTION
### 📌 개발 개요
- resolve #140 
- Sort 기준이 추가되고 나서, 커서를 추가 했어야 하는데 하지 않아서 발생한 오류입니다.
  <br>

### 💻  작업 및 변경 사항
- `Novel`
  - `grade`가 Null이 아닌 0을 반환하도록 쿼리를 수정하였습니다.
- `RequestDto` 에 좋아요 수, 리뷰 수, 평점, 소설 추가 일자를 추가 하였습니다.
  - 원하는 정렬 기준에 해당하는 값을 보내면 됩니다.
    - ex) 좋아요 순 정렬일 때는 마지막 작품의 `novelId, grade`, `Sort`
    - ex) 최신 정렬일 때는 마지막 작품의 `novelId, createdDate`, `Sort`
- 이제 들어온 값에 따라 올바르게 정렬하여 조회가 가능합니다.
  - 기존에는 novelId로만 페이징을 하였는데, 이제는 정렬 기준으로 사용할 값도 같이 사용합니다.
  <br>

### ✅ Point
- no-offset 방식이 적용된 기능에는 이와 같은 수정이 필요합니다.
- 코드가 꽤나 변경되어서 프론트도 수정이 좀 필요합니다.
- 궁금한 부분 있으면 질문해주세요!                   
  <br>