### PR TITLE
[REFACTOR] Recommend 도메인 리팩터링

### DIFF
--- a/src/main/java/com/yju/toonovel/domain/novel/controller/NovelController.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/controller/NovelController.java
@@ -79,4 +79,12 @@ public class NovelController {
 		@AuthenticationPrincipal JwtAuthentication user) {
 		return novelService.findNovelByAuthor(requestDto, user.userId);
 	}
+
+	@Operation(summary = "추천 작품 조회 요청")
+	@ApiResponse(responseCode = "200", description = "요청 성공")
+	@GetMapping("/recommend")
+	@ResponseStatus(HttpStatus.OK)
+	public List<NovelPaginationResponseDto> getNovelRecommend(@AuthenticationPrincipal JwtAuthentication user) {
+		return novelService.findNovelByRecommendation(user.userId);
+	}
 }

--- a/src/main/java/com/yju/toonovel/domain/novel/exception/NovelRecommendationNotExistException.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/exception/NovelRecommendationNotExistException.java
@@ -1,0 +1,12 @@
+package com.yju.toonovel.domain.novel.exception;
+
+import com.yju.toonovel.global.error.exception.BusinessException;
+import com.yju.toonovel.global.error.exception.ErrorCode;
+
+public class NovelRecommendationNotExistException extends BusinessException {
+
+	public NovelRecommendationNotExistException() {
+		super(ErrorCode.NOVEL_RECOMMENDATION_NOT_EXIST);
+	}
+
+}

--- a/src/main/java/com/yju/toonovel/domain/novel/service/NovelService.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/service/NovelService.java
@@ -90,21 +90,16 @@ public class NovelService {
 
 	@Transactional
 	public List<NovelPaginationResponseDto> findNovelByRecommendation(Long userId) {
+		List<Long> recommendList = getNovelRecommendation(userId);
 
-		List<Integer> recommendList = getNovelRecommendation(userId);
-
-		List<Long> novelIdList = recommendList.stream()
-			.map(novelId -> Long.valueOf(novelId))
-			.collect(Collectors.toList());
-
-		return novelRepository.findNovelsByNovelIdList(novelIdList)
+		return novelRepository.findNovelsByNovelIdList(recommendList)
 			.stream()
 			.map(novel -> NovelPaginationResponseDto.from(novel))
 			.collect(Collectors.toList());
 
 	}
 
-	private List<Integer> getNovelRecommendation(Long userId) {
+	private List<Long> getNovelRecommendation(Long userId) {
 		try {
 			URI uri = UriComponentsBuilder
 				.fromUriString(machineLearningServer)
@@ -113,7 +108,7 @@ public class NovelService {
 				.build()
 				.toUri();
 
-			return List.of(restTemplate.getForObject(uri, Integer[].class));
+			return List.of(restTemplate.getForObject(uri, Long[].class));
 
 		} catch (HttpServerErrorException ex) {
 			throw new NovelRecommendationNotExistException();

--- a/src/main/java/com/yju/toonovel/domain/novel/service/NovelService.java
+++ b/src/main/java/com/yju/toonovel/domain/novel/service/NovelService.java
@@ -1,10 +1,15 @@
 package com.yju.toonovel.domain.novel.service;
 
+import java.net.URI;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import com.yju.toonovel.domain.novel.dto.NovelDetailResponseDto;
 import com.yju.toonovel.domain.novel.dto.NovelPaginationRequestDto;
@@ -17,6 +22,7 @@ import com.yju.toonovel.domain.novel.entity.NovelPlatform;
 import com.yju.toonovel.domain.novel.entity.Platform;
 import com.yju.toonovel.domain.novel.exception.AuthorNotFoundException;
 import com.yju.toonovel.domain.novel.exception.NovelNotFoundException;
+import com.yju.toonovel.domain.novel.exception.NovelRecommendationNotExistException;
 import com.yju.toonovel.domain.novel.exception.PlatformNotFoundException;
 import com.yju.toonovel.domain.novel.repository.LikeNovelRepository;
 import com.yju.toonovel.domain.novel.repository.NovelPlatformRepository;
@@ -38,6 +44,10 @@ public class NovelService {
 	private final UserRepository userRepository;
 	private final NovelPlatformRepository novelPlatformRepository;
 	private final PlatformRepository platformRepository;
+	private final RestTemplate restTemplate;
+
+	@Value("${server.machineLearning}")
+	private String machineLearningServer;
 
 	@Transactional
 	public List<NovelPaginationResponseDto> findAllNovel(NovelPaginationRequestDto requestDto) {
@@ -76,6 +86,38 @@ public class NovelService {
 			return PlatformResponseDto.from(platform, novelPlatform.getUrl());
 		}).collect(Collectors.toList());
 		return NovelDetailResponseDto.from(novel, platforms);
+	}
+
+	@Transactional
+	public List<NovelPaginationResponseDto> findNovelByRecommendation(Long userId) {
+
+		List<Integer> recommendList = getNovelRecommendation(userId);
+
+		List<Long> novelIdList = recommendList.stream()
+			.map(novelId -> Long.valueOf(novelId))
+			.collect(Collectors.toList());
+
+		return novelRepository.findNovelsByNovelIdList(novelIdList)
+			.stream()
+			.map(novel -> NovelPaginationResponseDto.from(novel))
+			.collect(Collectors.toList());
+
+	}
+
+	private List<Integer> getNovelRecommendation(Long userId) {
+		try {
+			URI uri = UriComponentsBuilder
+				.fromUriString(machineLearningServer)
+				.path("/recommend/" + userId)
+				.encode()
+				.build()
+				.toUri();
+
+			return List.of(restTemplate.getForObject(uri, Integer[].class));
+
+		} catch (HttpServerErrorException ex) {
+			throw new NovelRecommendationNotExistException();
+		}
 	}
 
 	@Transactional

--- a/src/main/java/com/yju/toonovel/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/yju/toonovel/global/config/RestTemplateConfig.java
@@ -1,0 +1,19 @@
+package com.yju.toonovel.global.config;
+
+import java.time.Duration;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+	@Bean
+	public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
+		return restTemplateBuilder
+			.setConnectTimeout(Duration.ofSeconds(10))
+			.setReadTimeout(Duration.ofSeconds(10))
+			.build();
+	}
+}

--- a/src/main/java/com/yju/toonovel/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/yju/toonovel/global/error/exception/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
 	NOVEL_GENRE_NOT_FOUND(HttpStatus.NOT_FOUND, "N003", "존재하지 않는 장르입니다."),
 	AUTHOR_NOT_FOUND(HttpStatus.NOT_FOUND, "N004", "존재하지 않는 작가입니다."),
 	NOVEL_NOT_MATCH_AUTHOR(HttpStatus.FORBIDDEN, "N005", "로그인한 작가가 연재한 작품이 아닙니다."),
+	NOVEL_RECOMMENDATION_NOT_EXIST(HttpStatus.NOT_FOUND, "N006", "추천 목록이 존재하지 않습니다."),
 
 	//Review
 	REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "R001", "존재하지 않는 리뷰입니다."),


### PR DESCRIPTION
### 📌 개발 개요
- resolve #145 
- `Recommend` 기능을 `Novel` 도메인으로 이동시키고, 리팩터링
  <br>

### 💻  작업 및 변경 사항
- 더 이상 `Recommend` 도메인을 사용하지 않습니다.
  - 필요 없다고 판단되는 모델 수동 업데이트 API를 제거할 예정입니다.
  - 추천 API를 `Novel` 도메인으로 이동시킵니다.
  - 버저닝이 애매하기는 판단하여, 프론트엔드 수정이 끝나면 해당 도메인을 삭제 처리 하겠습니다.
- `Novel` 도메인에서 추천 기능을 맡습니다.
  - `api/v1/novel/recommend` 로 API 경로 변경이 필요합니다.
- RestTemplate를 주입 받아서 사용합니다.
  - `connectTimeout`, `readTimeout` 을 설정하였습니다.
  - FastAPI에서 반환하는 에러에 대해서 예외 처리를 추가하였습니다.
  <br>

### ✅ Point
- `Recommend` 도메인을 그대로 남겨두고, 사용하는 방법도 고려했습니다.
  'Service 레이어간의 의존도가 높아지는 게 아닌가?' 하는 고민을 하면서 여러 가지 방법을 생각했었습니다.
  `Controller` 에서 필요한 서비스를 모두 호출하는 방법, 상위 `Service` 를 만드는 방법,, 여러가지를 고민했는데, 현재로서는 `Novel` 도메인에 책임을 맡기고, 필요가 없어진 `Recommend` 도메인을 삭제하는 게 제일 좋다고 생각했습니다.

- `Recommend` 도메인은 프론트 수정이 끝나면 제거 하겠습니다.
- 의견 있으시면 남겨주세요!
  <br>