### PR TITLE
[REFACTOR] Chatting 도메인 리팩토링

### DIFF
--- a/src/main/java/com/yju/toonovel/domain/chatting/controller/ChatRoomHttpController.java
+++ b/src/main/java/com/yju/toonovel/domain/chatting/controller/ChatRoomHttpController.java
@@ -87,7 +87,7 @@ public class ChatRoomHttpController {
 	@GetMapping()
 	@ResponseStatus(HttpStatus.OK)
 	public List<ChatRoomResponseDto> getAllChatRoom(@AuthenticationPrincipal JwtAuthentication user) {
-		return chatRoomService.getAllChatRoom(user.userId);
+		return chatRoomService.findAllChatRoom(user.userId);
 	}
 
 	@Operation(summary = "채팅 목록 조회 (요청 날짜 형식 yyyy-MM-dd)")
@@ -100,7 +100,7 @@ public class ChatRoomHttpController {
 		@AuthenticationPrincipal JwtAuthentication user,
 		@PathVariable("rid") Long rid,
 		@RequestParam(value = "date", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
-		return chatRoomService.getChatList(user.userId, rid, date);
+		return chatRoomService.findChatList(user.userId, rid, date);
 	}
 
 	@Operation(summary = "답장 목록 조회 (요청 날짜 형식 yyyy-MM-dd)")
@@ -113,6 +113,6 @@ public class ChatRoomHttpController {
 		@AuthenticationPrincipal JwtAuthentication user,
 		@PathVariable("rid") Long rid,
 		@RequestParam(value = "date", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
-		return chatRoomService.getReplyList(user.userId, rid, date);
+		return chatRoomService.findReplyList(user.userId, rid, date);
 	}
 }

--- a/src/main/java/com/yju/toonovel/domain/chatting/dto/ChatDto.java
+++ b/src/main/java/com/yju/toonovel/domain/chatting/dto/ChatDto.java
@@ -3,13 +3,13 @@ package com.yju.toonovel.domain.chatting.dto;
 import java.time.LocalDateTime;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 
 import org.hibernate.validator.constraints.Length;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
@@ -17,27 +17,27 @@ import lombok.ToString;
 @Getter
 @ToString
 @Setter
-@NoArgsConstructor
 public class ChatDto {
 	@Schema(description = "채팅 ID")
 	private Long chatId;
 	@Schema(description = "채팅 작성자 이름")
 	private String senderName;
 	@Schema(description = "채팅 작성자 userId")
-	private Long senderId;
+	@NotNull
+	private final Long senderId;
 	@Schema(description = "채팅 작성자가 채팅방의 주인인지")
 	private boolean isCreator;
 	@NotBlank
 	@Length(max = 300)
 	@Schema(description = "채팅 내용")
-	private String message;
+	private final String message;
 	@Schema(description = "메시지 필터링 결과 'ok' or 'bad'")
 	private String filterResult;
 	@Schema(description = "채팅을 보낸 시간")
 	private LocalDateTime createdDate;
 
 	@Builder
-	public ChatDto(
+	private ChatDto(
 		Long chatId,
 		String senderName,
 		Long senderId,

--- a/src/main/java/com/yju/toonovel/domain/chatting/dto/ChatRoomCreateRequestDto.java
+++ b/src/main/java/com/yju/toonovel/domain/chatting/dto/ChatRoomCreateRequestDto.java
@@ -5,7 +5,6 @@ import javax.validation.constraints.NotBlank;
 import org.hibernate.validator.constraints.Length;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -21,9 +20,4 @@ public class ChatRoomCreateRequestDto {
 	private String chatRoomName;
 	@Schema(description = "채팅방을 생성한 유저의 userId")
 	private Long userId;
-
-	@Builder
-	public ChatRoomCreateRequestDto(String chatRoomName) {
-		this.chatRoomName = chatRoomName;
-	}
 }

--- a/src/main/java/com/yju/toonovel/domain/chatting/dto/ChatRoomResponseDto.java
+++ b/src/main/java/com/yju/toonovel/domain/chatting/dto/ChatRoomResponseDto.java
@@ -1,26 +1,22 @@
 package com.yju.toonovel.domain.chatting.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Schema(description = "채팅방 조회 응답 DTO")
 @Getter
 @ToString
-@NoArgsConstructor
 public class ChatRoomResponseDto {
 	@Schema(description = "채팅방 번호")
-	private Long chatRoomId;
+	private final Long chatRoomId;
 	@Schema(description = "채팅방 이름")
-	private String chatRoomName;
+	private final String chatRoomName;
 	@Schema(description = "채팅방을 생성한 작가의 닉네임")
-	private String nickname;
+	private final String nickname;
 	@Schema(description = "작가의 userId")
-	private Long userId;
+	private final Long userId;
 
-	@Builder
 	public ChatRoomResponseDto(Long chatRoomId, String chatRoomName, String nickname, Long userId) {
 		this.chatRoomId = chatRoomId;
 		this.chatRoomName = chatRoomName;

--- a/src/main/java/com/yju/toonovel/domain/chatting/dto/FilterChatRequestDto.java
+++ b/src/main/java/com/yju/toonovel/domain/chatting/dto/FilterChatRequestDto.java
@@ -2,16 +2,20 @@ package com.yju.toonovel.domain.chatting.dto;
 
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
 public class FilterChatRequestDto {
 
-	private String message;
+	private final String message;
 
 	@Builder
-	public FilterChatRequestDto(String message) {
+	private FilterChatRequestDto(String message) {
 		this.message = message;
+	}
+
+	public static FilterChatRequestDto of(String message) {
+		return FilterChatRequestDto.builder()
+			.message(message)
+			.build();
 	}
 }

--- a/src/main/java/com/yju/toonovel/domain/chatting/dto/FilterChatResponseDto.java
+++ b/src/main/java/com/yju/toonovel/domain/chatting/dto/FilterChatResponseDto.java
@@ -1,16 +1,12 @@
 package com.yju.toonovel.domain.chatting.dto;
 
-import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
 public class FilterChatResponseDto {
 
-	private String filteredResult;
+	private final String filteredResult;
 
-	@Builder
 	public FilterChatResponseDto(String filteredResult) {
 		this.filteredResult = filteredResult;
 	}

--- a/src/main/java/com/yju/toonovel/domain/chatting/dto/ReplyDto.java
+++ b/src/main/java/com/yju/toonovel/domain/chatting/dto/ReplyDto.java
@@ -3,6 +3,7 @@ package com.yju.toonovel.domain.chatting.dto;
 import java.time.LocalDateTime;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 
 import org.hibernate.validator.constraints.Length;
 
@@ -21,6 +22,7 @@ public class ReplyDto {
 	@Schema(description = "답장 번호")
 	private Long replyId;
 	@Schema(description = "답장을 보낸 작가의 userId")
+	@NotNull
 	private Long senderId;
 	@Schema(description = "답장을 보낸 작가의 닉네임")
 	private String senderName;
@@ -31,8 +33,10 @@ public class ReplyDto {
 	@Schema(description = "답장을 보낸 시간")
 	private LocalDateTime createdDate;
 	@Schema(description = "원문 채팅의 채팅 번호")
+	@NotNull
 	private Long chatId;
 	@Schema(description = "원문 채팅의 채팅 내용")
+	@NotBlank
 	private String userMessage;
 	@Schema(description = "원문 채팅을 보낸 유저의 닉네임")
 	private String userName;

--- a/src/main/java/com/yju/toonovel/domain/chatting/service/ChatRoomService.java
+++ b/src/main/java/com/yju/toonovel/domain/chatting/service/ChatRoomService.java
@@ -131,7 +131,7 @@ public class ChatRoomService {
 		chatRoomRepository.save(chatRoom);
 	}
 
-	public List<ChatRoomResponseDto> getAllChatRoom(Long userId) {
+	public List<ChatRoomResponseDto> findAllChatRoom(Long userId) {
 		User user = userRepository.findByUserId(userId)
 			.orElseThrow(() -> new UserNotFoundException());
 
@@ -139,7 +139,7 @@ public class ChatRoomService {
 	}
 
 	@Transactional
-	public List<ChatDto> getChatList(Long userId, Long rid, LocalDate date) {
+	public List<ChatDto> findChatList(Long userId, Long rid, LocalDate date) {
 		User user = userRepository.findByUserId(userId)
 			.orElseThrow(() -> new UserNotFoundException());
 
@@ -152,12 +152,12 @@ public class ChatRoomService {
 		}
 
 		return (Objects.equals(chatRoom.getUser().getUserId(), user.getUserId()))
-			? getChatListToAuthor(chatRoom, date)
-			: getChatListToUser(chatRoom, user, date);
+			? findChatListToAuthor(chatRoom, date)
+			: findChatListToUser(chatRoom, user, date);
 	}
 
 	@Transactional
-	public List<ReplyDto> getReplyList(Long userId, Long rid, LocalDate date) {
+	public List<ReplyDto> findReplyList(Long userId, Long rid, LocalDate date) {
 		User user = userRepository.findByUserId(userId)
 			.orElseThrow(() -> new UserNotFoundException());
 
@@ -173,7 +173,7 @@ public class ChatRoomService {
 	}
 
 	// 요청한 사람이 채팅방의 주인인 경우
-	private List<ChatDto> getChatListToAuthor(ChatRoom chatRoom, LocalDate date) {
+	private List<ChatDto> findChatListToAuthor(ChatRoom chatRoom, LocalDate date) {
 		if (date == null) {
 			return chatCustomRepository.findAllByChatRoomToAuthor(chatRoom)
 				.stream().map(chat -> {
@@ -198,7 +198,7 @@ public class ChatRoomService {
 	}
 
 	// 요청한 사람이 채팅방의 주인이 아닌 경우
-	private List<ChatDto> getChatListToUser(ChatRoom chatRoom, User user, LocalDate date) {
+	private List<ChatDto> findChatListToUser(ChatRoom chatRoom, User user, LocalDate date) {
 		if (date == null) {
 			return chatCustomRepository
 				.findAllByChatRoomToUser(chatRoom, user.getUserId(), chatRoom.getUser())

--- a/src/main/java/com/yju/toonovel/domain/chatting/service/ChatService.java
+++ b/src/main/java/com/yju/toonovel/domain/chatting/service/ChatService.java
@@ -89,7 +89,7 @@ public class ChatService {
 		dto.setCreatedDate(chat.getCreatedDate());
 	}
 
-	public FilterChatResponseDto filterChat(String message) {
+	private FilterChatResponseDto filterChat(String message) {
 		RestTemplate restTemplate = new RestTemplate();
 
 		URI uri = UriComponentsBuilder

--- a/src/main/java/com/yju/toonovel/domain/chatting/service/ChatService.java
+++ b/src/main/java/com/yju/toonovel/domain/chatting/service/ChatService.java
@@ -100,10 +100,7 @@ public class ChatService {
 			.expand(message)
 			.toUri();
 
-		FilterChatRequestDto request = FilterChatRequestDto
-			.builder()
-			.message(message)
-			.build();
+		FilterChatRequestDto request = FilterChatRequestDto.of(message);
 		ResponseEntity<FilterChatResponseDto> response =
 			restTemplate.postForEntity(uri, request, FilterChatResponseDto.class);
 

--- a/src/main/java/com/yju/toonovel/domain/chatting/service/ChatService.java
+++ b/src/main/java/com/yju/toonovel/domain/chatting/service/ChatService.java
@@ -44,6 +44,7 @@ public class ChatService {
 	private final ChatRoomRepository chatRoomRepository;
 	private final ReplyRepository replyRepository;
 	private final long chatLimit = 3;
+	private final RestTemplate restTemplate;
 
 	@Value("${server.machineLearning}")
 	private String machineLearningServer;
@@ -90,8 +91,6 @@ public class ChatService {
 	}
 
 	private FilterChatResponseDto filterChat(String message) {
-		RestTemplate restTemplate = new RestTemplate();
-
 		URI uri = UriComponentsBuilder
 			.fromUriString(machineLearningServer)
 			.path("/filter")


### PR DESCRIPTION
### 📌 개발 개요
- resolve #151
> Chatting 도메인 중 팀에서 정한 규칙과 맞지 않은 부분 수정

  <br>

### 💻  작업 및 변경 사항
- Service, Controller
  - `get~~` 와 같은 메서드명을 `find~~`로 통일
  - 다른 클래스에서 사용되지 않는 메서드의 접근제어자를 `public`으로 변경
- Dto
  - 객체 생성 방식을 정적 팩토리 메소드로 통일
    - 따라서, 다른 클래스에서 사용되지 않는 Builder 패턴 생성자를 `private`으로 변경
  - Valiation 적용
  - `final` 키워드 적용
  <br>

### ✅ Point
- `ChatCustomRepositoryImpl`의 코드 중에
```
	@Override
	public List<Chat> findAllByChatRoomToAuthor(ChatRoom chatRoom) {
		return jpaQueryFactory
			.selectFrom(chat)
			.where(
				chat.chatRoom.eq(chatRoom),
				chat.createdDate.between(
					LocalDate.now().minusDays(7).atStartOfDay(), LocalDate.now().plusDays(1).atStartOfDay()
				)
			)
			.orderBy(chat.chatId.desc())
			.fetch();
	}

	@Override
	public List<Chat> findAllByChatRoomAndDateToAuthor(ChatRoom chatRoom, LocalDate date) {
		return jpaQueryFactory
			.selectFrom(chat)
			.where(
				chat.chatRoom.eq(chatRoom),
				chat.createdDate.between(date.atStartOfDay(), date.plusDays(1).atStartOfDay())
			)
			.orderBy(chat.chatId.desc())
			.fetch();
	}

        ...
```
- 이러한 부분이 있습니다. 코드가 유사한 탓에 처음엔 하나의 메서드로 통일할려고 했습니다.
- 하지만 이는 _**요청한 사람이 채팅방의 주인인지**_ 혹은 _**채팅을 쓴 사람이 채팅방의 주인인지**_ 여부에 따라서 다른 메서드를 사용합니다.
- 이 경우 _**요청한 사람이 채팅방의 주인인지**_ 혹은 _**채팅을 쓴 사람이 채팅방의 주인인지**_ 판별하는 것은 `Repository`의 역할이 아니라, `Service`의 역할이라고 생각해 기존 코드대로 사용했습니다. 만약 다른 의견 있으시면 코멘트 부탁드립니다.
  <br>